### PR TITLE
Useful stuff

### DIFF
--- a/src/main/java/dev/waterdog/network/downstream/ConnectedDownstreamHandler.java
+++ b/src/main/java/dev/waterdog/network/downstream/ConnectedDownstreamHandler.java
@@ -96,6 +96,10 @@ public class ConnectedDownstreamHandler extends AbstractDownstreamHandler {
         }
 
         ServerInfo serverInfo = this.player.getProxy().getServerInfo(packet.getAddress());
+        if (serverInfo == null) {
+            serverInfo = this.player.getProxy().getServerInfo(packet.getAddress(), packet.getPort());
+        }
+
         if (serverInfo != null) {
             this.player.connect(serverInfo);
             throw CancelSignalException.CANCEL;

--- a/src/main/java/dev/waterdog/utils/config/ServerList.java
+++ b/src/main/java/dev/waterdog/utils/config/ServerList.java
@@ -19,7 +19,7 @@ import dev.waterdog.network.ServerInfo;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.TreeMap;
 
 /**
  * This is a wrapper class for a map mapping all the server names to corresponding ServerInfo instances.
@@ -27,7 +27,7 @@ import java.util.HashMap;
  */
 public class ServerList {
 
-    private final HashMap<String, ServerInfo> serverList = new HashMap<>();
+    private final TreeMap<String, ServerInfo> serverList = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     public ServerInfo get(String name) {
         return this.serverList.get(name);


### PR DESCRIPTION
Change `serverList` from HashMap to TreeMap using case insensitive order for finding server infos by name even if they dont have the same case.

If the transfer packet handler can´t find the server info by the name it tries to resolve it by the address and port given.