### PR TITLE
Allow waterdog.yml as alias for plugin.yml

### DIFF
--- a/src/main/java/dev/waterdog/plugin/PluginLoader.java
+++ b/src/main/java/dev/waterdog/plugin/PluginLoader.java
@@ -66,9 +66,13 @@ public class PluginLoader {
 
     protected PluginYAML loadPluginData(File file, Yaml yaml) {
         try (JarFile pluginJar = new JarFile(file)) {
-            JarEntry configEntry = pluginJar.getJarEntry("plugin.yml");
+            JarEntry configEntry = pluginJar.getJarEntry("waterdog.yml");
             if (configEntry == null) {
-                MainLogger.getLogger().warning("Jar file " + file.getName() + " doesnt contain a plugin.yml!");
+              configEntry = pluginJar.getJarEntry("plugin.yml");
+            }
+
+            if (configEntry == null) {
+                MainLogger.getLogger().warning("Jar file " + file.getName() + " doesnt contain a waterdog.yml or plugin.yml!");
                 return null;
             }
 

--- a/src/main/java/dev/waterdog/plugin/PluginLoader.java
+++ b/src/main/java/dev/waterdog/plugin/PluginLoader.java
@@ -68,7 +68,7 @@ public class PluginLoader {
         try (JarFile pluginJar = new JarFile(file)) {
             JarEntry configEntry = pluginJar.getJarEntry("waterdog.yml");
             if (configEntry == null) {
-              configEntry = pluginJar.getJarEntry("plugin.yml");
+                configEntry = pluginJar.getJarEntry("plugin.yml");
             }
 
             if (configEntry == null) {


### PR DESCRIPTION
This pull requests allows the plugin.yml to be named waterdog.yml too. This is useful for cross-platform applications which can run on bukkit servers as well as on waterdog proxies.