### PR TITLE
Add event-field 'args' in DispatchCommandEvent

### DIFF
--- a/src/main/java/dev/waterdog/ProxyServer.java
+++ b/src/main/java/dev/waterdog/ProxyServer.java
@@ -222,14 +222,15 @@ public class ProxyServer {
 
     public boolean dispatchCommand(CommandSender sender, String message) {
         String[] args = message.split(" ");
-        DispatchCommandEvent event = new DispatchCommandEvent(sender, args[0], Arrays.copyOfRange(args, 1, args.length));
+        String[] shiftedArgs = Arrays.copyOfRange(args, 1, args.length);
+        DispatchCommandEvent event = new DispatchCommandEvent(sender, args[0], shiftedArgs);
 
         this.eventManager.callEvent(event);
         if (event.isCancelled()) {
             return false;
         }
 
-        return this.commandMap.handleCommand(sender, args[0], Arrays.copyOfRange(args, 1, args.length));
+        return this.commandMap.handleCommand(sender, args[0], shiftedArgs);
     }
 
     public CompletableFuture<BedrockClient> bindClient(ProtocolVersion protocol) {

--- a/src/main/java/dev/waterdog/ProxyServer.java
+++ b/src/main/java/dev/waterdog/ProxyServer.java
@@ -221,13 +221,14 @@ public class ProxyServer {
     }
 
     public boolean dispatchCommand(CommandSender sender, String message) {
-        DispatchCommandEvent event = new DispatchCommandEvent(sender, message);
-        this.eventManager.callEvent(event);
+        String[] args = message.split(" ");
+        DispatchCommandEvent event = new DispatchCommandEvent(sender, args[0], Arrays.copyOfRange(args, 1, args.length));
 
+        this.eventManager.callEvent(event);
         if (event.isCancelled()) {
             return false;
         }
-        String[] args = message.split(" ");
+
         return this.commandMap.handleCommand(sender, args[0], Arrays.copyOfRange(args, 1, args.length));
     }
 

--- a/src/main/java/dev/waterdog/event/defaults/DispatchCommandEvent.java
+++ b/src/main/java/dev/waterdog/event/defaults/DispatchCommandEvent.java
@@ -28,10 +28,12 @@ public class DispatchCommandEvent extends Event implements CancellableEvent {
 
     private final CommandSender sender;
     private final String command;
+    private final String[] args;
 
-    public DispatchCommandEvent(CommandSender sender, String command) {
+    public DispatchCommandEvent(CommandSender sender, String command, String[] args) {
         this.sender = sender;
         this.command = command;
+        this.args = args;
     }
 
     public CommandSender getSender() {
@@ -40,5 +42,9 @@ public class DispatchCommandEvent extends Event implements CancellableEvent {
 
     public String getCommand() {
         return this.command;
+    }
+
+    public String[] getArgs() {
+        return this.args;
     }
 }


### PR DESCRIPTION
# Disclaimer
!!! This is my first contribution to PR, so there migth me some typos or a different code-style. If you see something annoying you, please tell me so I could fix that!!!

# API-Changes
This PR brings the ability to directly reading the arguments passed in a command through a new field, `DispatchCommandEvent#args`

# Tests
Tested through a custom Plugin on Java11, went succesful.

