### PR TITLE
Removed useless method PreTransferEvent#setPlayer

### DIFF
--- a/src/main/java/dev/waterdog/event/defaults/PreTransferEvent.java
+++ b/src/main/java/dev/waterdog/event/defaults/PreTransferEvent.java
@@ -33,10 +33,6 @@ public class PreTransferEvent extends PlayerEvent implements CancellableEvent {
         this.targetServer = targetServer;
     }
 
-    public void setPlayer(ProxiedPlayer player) {
-        this.player = player;
-    }
-
     public ServerInfo getTargetServer() {
         return this.targetServer;
     }


### PR DESCRIPTION
This PR includes removing the method PreTransferEvent#setPlayer, because I see no use for it