### PR TITLE
Add support for IPv6 Addresses

### DIFF
--- a/src/main/java/dev/waterdog/ProxyServer.java
+++ b/src/main/java/dev/waterdog/ProxyServer.java
@@ -105,6 +105,11 @@ public class ProxyServer {
 
         this.configurationManager = new ConfigurationManager(this);
         this.configurationManager.loadProxyConfig();
+
+        if(!this.getConfiguration().isIpv6Enabled()){
+           // System.setProperty("java.net.preferIPv4Stack", "true");//I dont know why, but it was here before so better not remove it
+        }
+
         if (this.getConfiguration().isDebug()) {
             WaterdogPE.setLoggerLevel(Level.DEBUG);
         }

--- a/src/main/java/dev/waterdog/ProxyServer.java
+++ b/src/main/java/dev/waterdog/ProxyServer.java
@@ -107,7 +107,7 @@ public class ProxyServer {
         this.configurationManager.loadProxyConfig();
 
         if(!this.getConfiguration().isIpv6Enabled()){
-           // System.setProperty("java.net.preferIPv4Stack", "true");//I dont know why, but it was here before so better not remove it
+            System.setProperty("java.net.preferIPv4Stack", "true");//I dont know why, but it was here before so better not remove it
         }
 
         if (this.getConfiguration().isDebug()) {

--- a/src/main/java/dev/waterdog/WaterdogPE.java
+++ b/src/main/java/dev/waterdog/WaterdogPE.java
@@ -33,7 +33,6 @@ public class WaterdogPE {
         System.out.println("Starting WaterdogPE....");
         System.setProperty("log4j.skipJansi", "false");
         System.setSecurityManager(null);
-        System.setProperty("java.net.preferIPv4Stack", "true");
         System.getProperties().putIfAbsent("io.netty.allocator.type", "unpooled");
         ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.DISABLED);
 

--- a/src/main/java/dev/waterdog/utils/ProxyConfig.java
+++ b/src/main/java/dev/waterdog/utils/ProxyConfig.java
@@ -87,7 +87,7 @@ public class ProxyConfig extends YamlConfig {
 
     @Path("enable_ipv6")
     @Comment("If enabled, the proxy will be able to bind to an Ipv6 Address")
-    private boolean enableIpv6 = true;
+    private boolean enableIpv6 = false;
 
     @Path("use_login_extras")
     @Comment("If enabled, the proxy will pass information like XUID or IP to the downstream server using custom fields in the LoginPacket")

--- a/src/main/java/dev/waterdog/utils/ProxyConfig.java
+++ b/src/main/java/dev/waterdog/utils/ProxyConfig.java
@@ -85,6 +85,10 @@ public class ProxyConfig extends YamlConfig {
     @Comment("If enabled, only players which are authenticated with XBOX Live can join. If disabled, anyone can connect *with any name*")
     private boolean onlineMode = true;
 
+    @Path("enable_ipv6")
+    @Comment("If enabled, the proxy will be able to bind to an Ipv6 Address")
+    private boolean enableIpv6 = true;
+
     @Path("use_login_extras")
     @Comment("If enabled, the proxy will pass information like XUID or IP to the downstream server using custom fields in the LoginPacket")
     private boolean useLoginExtras = true;
@@ -251,6 +255,14 @@ public class ProxyConfig extends YamlConfig {
 
     public boolean injectCommands() {
         return this.injectCommands;
+    }
+
+    public boolean isIpv6Enabled() {
+        return enableIpv6;
+    }
+
+    public void setIpv6Enabled(boolean enableIpv6) {
+        this.enableIpv6 = enableIpv6;
     }
 
     public boolean enabledResourcePacks() {

--- a/src/main/java/dev/waterdog/utils/config/InetSocketAddressConverter.java
+++ b/src/main/java/dev/waterdog/utils/config/InetSocketAddressConverter.java
@@ -31,7 +31,7 @@ public class InetSocketAddressConverter implements Converter {
 
     @Override
     public Object toConfig(Class<?> type, Object object, ParameterizedType parameterizedType) throws Exception {
-        if (object == null){
+        if (object == null) {
             return null;
         }
         InetSocketAddress address = (InetSocketAddress) object;
@@ -44,8 +44,9 @@ public class InetSocketAddressConverter implements Converter {
             return null;
         }
         String string = (String) object;
-        String[] parts = string.split(":");
-        return new InetSocketAddress(parts[0], Integer.parseInt(parts[1]));
+        String address = string.substring(0, string.lastIndexOf(":"));
+        int port = Integer.parseInt(string.substring(string.lastIndexOf(":") + 1));
+        return new InetSocketAddress(address, port);
     }
 
     @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -42,7 +42,7 @@ enable_debug: false
 # Enable online mode to prevent unauthorized players to join.
 online_mode: true
 #If enabled, the proxy will be able to bind to an Ipv6 Address.
-enable_ipv6: true
+enable_ipv6: false
 # Some server software may have problem with extra attributes in packets. You can disable it here.
 use_login_extras: true
 # Disable if you do not want ho handle query requests.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -41,6 +41,8 @@ permissions_default:
 enable_debug: false
 # Enable online mode to prevent unauthorized players to join.
 online_mode: true
+#If enabled, the proxy will be able to bind to an Ipv6 Address.
+enable_ipv6: true
 # Some server software may have problem with extra attributes in packets. You can disable it here.
 use_login_extras: true
 # Disable if you do not want ho handle query requests.


### PR DESCRIPTION
The InetSocketAddress deserialization code couldn't handle IPv6 Addresses, also there was a property set which prevented IPv6 Addresses from binding.