### PR TITLE
Updates

### DIFF
--- a/src/main/java/dev/waterdog/ProxyServer.java
+++ b/src/main/java/dev/waterdog/ProxyServer.java
@@ -86,14 +86,14 @@ public class ProxyServer {
         this.packsPath = this.dataPath.resolve("packs");
 
         if (!this.pluginPath.toFile().exists()) {
-            if(!this.pluginPath.toFile().mkdirs())
+            if(this.pluginPath.toFile().mkdirs())
                 this.logger.info("Created Plugin Folder at " + this.pluginPath.toString());
             else
                 this.logger.warning("Could not create Plugin Folder at " + this.pluginPath.toString());
         }
 
         if (!this.packsPath.toFile().exists()) {
-            if(!this.packsPath.toFile().mkdirs())
+            if(this.packsPath.toFile().mkdirs())
                 this.logger.info("Created Packs Folder at " + this.packsPath.toString());
             else
                 this.logger.warning("Could not create Packs Folder at " + this.packsPath.toString());

--- a/src/main/java/dev/waterdog/ProxyServer.java
+++ b/src/main/java/dev/waterdog/ProxyServer.java
@@ -86,13 +86,17 @@ public class ProxyServer {
         this.packsPath = this.dataPath.resolve("packs");
 
         if (!this.pluginPath.toFile().exists()) {
-            this.logger.info("Created Plugin Folder at " + this.pluginPath.toString());
-            this.pluginPath.toFile().mkdirs();
+            if(!this.pluginPath.toFile().mkdirs())
+                this.logger.info("Created Plugin Folder at " + this.pluginPath.toString());
+            else
+                this.logger.warning("Could not create Plugin Folder at " + this.pluginPath.toString());
         }
 
         if (!this.packsPath.toFile().exists()) {
-            this.logger.info("Created Packs Folder at " + this.packsPath.toString());
-            this.packsPath.toFile().mkdirs();
+            if(!this.packsPath.toFile().mkdirs())
+                this.logger.info("Created Packs Folder at " + this.packsPath.toString());
+            else
+                this.logger.warning("Could not create Packs Folder at " + this.packsPath.toString());
         }
 
         ThreadFactoryBuilder builder = new ThreadFactoryBuilder();

--- a/src/main/java/dev/waterdog/ProxyServer.java
+++ b/src/main/java/dev/waterdog/ProxyServer.java
@@ -86,14 +86,14 @@ public class ProxyServer {
         this.packsPath = this.dataPath.resolve("packs");
 
         if (!this.pluginPath.toFile().exists()) {
-            if(this.pluginPath.toFile().mkdirs())
+            if (this.pluginPath.toFile().mkdirs())
                 this.logger.info("Created Plugin Folder at " + this.pluginPath.toString());
             else
                 this.logger.warning("Could not create Plugin Folder at " + this.pluginPath.toString());
         }
 
         if (!this.packsPath.toFile().exists()) {
-            if(this.packsPath.toFile().mkdirs())
+            if (this.packsPath.toFile().mkdirs())
                 this.logger.info("Created Packs Folder at " + this.packsPath.toString());
             else
                 this.logger.warning("Could not create Packs Folder at " + this.packsPath.toString());

--- a/src/main/java/dev/waterdog/command/Command.java
+++ b/src/main/java/dev/waterdog/command/Command.java
@@ -39,6 +39,10 @@ public abstract class Command {
 
     private final CommandData data;
 
+    public Command(String name) {
+        this(name, CommandSettings.empty());
+    }
+
     public Command(String name, CommandSettings settings) {
         this.name = name;
         this.settings = settings;
@@ -78,7 +82,6 @@ public abstract class Command {
     public String[] getAliases() {
         return this.settings.getAliases();
     }
-
 
     public CommandData craftNetwork() {
         CommandParamData[][] parameterData = new CommandParamData[][]{{

--- a/src/main/java/dev/waterdog/command/CommandMap.java
+++ b/src/main/java/dev/waterdog/command/CommandMap.java
@@ -22,6 +22,16 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
  */
 public interface CommandMap {
 
+    boolean registerCommand(Command command);
+
+    /**
+     * @deprecated this should be replaced with CommandMap.registerAlias
+     *
+     * @param name the command name
+     * @param command the command which should be registered under the respective name
+     * @return true if this command could be registered under the respective name
+     */
+    @Deprecated
     boolean registerCommand(String name, Command command);
 
     boolean registerAlias(String name, Command command);

--- a/src/main/java/dev/waterdog/command/CommandMap.java
+++ b/src/main/java/dev/waterdog/command/CommandMap.java
@@ -22,6 +22,12 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
  */
 public interface CommandMap {
 
+    /**
+     * Registers a command with the respective name in it
+     *
+     * @param command the command which should be registered
+     * @return true if this command could be registered under the respective name
+     */
     boolean registerCommand(Command command);
 
     /**

--- a/src/main/java/dev/waterdog/command/CommandSettings.java
+++ b/src/main/java/dev/waterdog/command/CommandSettings.java
@@ -22,6 +22,8 @@ import dev.waterdog.utils.types.TranslationContainer;
  */
 public class CommandSettings {
 
+    private static final CommandSettings EMPTY_SETTINGS = CommandSettings.builder().build();
+
     private final String usageMessage;
     private final String description;
 
@@ -36,6 +38,10 @@ public class CommandSettings {
         this.permission = new TranslationContainer(permission).getTranslated();
         this.permissionMessage = new TranslationContainer(permissionMessage).getTranslated();
         this.aliases = aliases;
+    }
+
+    public static CommandSettings empty() {
+        return EMPTY_SETTINGS;
     }
 
     public static Builder builder() {

--- a/src/main/java/dev/waterdog/command/DefaultCommandMap.java
+++ b/src/main/java/dev/waterdog/command/DefaultCommandMap.java
@@ -26,11 +26,11 @@ public class DefaultCommandMap extends SimpleCommandMap {
     }
 
     public void registerDefaults() {
-        this.registerCommand("wdhelp", new HelpCommand());
-        this.registerCommand("wdlist", new ListCommand());
-        this.registerCommand("wdinfo", new InfoCommand());
-        this.registerCommand("server", new ServerCommand());
-        this.registerCommand("wdsend", new SendCommand());
-        this.registerCommand("end", new EndCommand());
+        this.registerCommand(new HelpCommand());
+        this.registerCommand(new ListCommand());
+        this.registerCommand(new InfoCommand());
+        this.registerCommand(new ServerCommand());
+        this.registerCommand(new SendCommand());
+        this.registerCommand(new EndCommand());
     }
 }

--- a/src/main/java/dev/waterdog/command/SimpleCommandMap.java
+++ b/src/main/java/dev/waterdog/command/SimpleCommandMap.java
@@ -37,8 +37,20 @@ public class SimpleCommandMap implements CommandMap {
     }
 
     @Override
+    @Deprecated
     public boolean registerCommand(String name, Command command) {
         if (this.commandsMap.putIfAbsent(name.toLowerCase(), command) != null) {
+            return false;
+        }
+        for (String alias : command.getAliases()) {
+            this.registerAlias(alias, command);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean registerCommand(Command command) {
+        if (this.commandsMap.putIfAbsent(command.getName().toLowerCase(), command) != null) {
             return false;
         }
         for (String alias : command.getAliases()) {


### PR DESCRIPTION
This pull request implements:
- Warnings if the plugin and packs directory could not be created
- CommandSettings.empty() to prevent multiple instances of the same default CommandSettings

This pull request changes:
- CommandMap.registerCommand to only accept the command param as the name is already identified in the command class and other names should be registered with CommandMap.registerAlias

This pull request deprecates:
- CommandMap.registerCommand with name and command param as the respective command name is already identified in the command class
