### PR TITLE
Fixed client stuck at 1MB when downloading resourcepacks bigger than 1MB

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/packs/types/ZipResourcePack.java
+++ b/src/main/java/dev/waterdog/waterdogpe/packs/types/ZipResourcePack.java
@@ -95,7 +95,8 @@ public class ZipResourcePack extends ResourcePack {
 
         ByteBuffer cachedPack = this.getCachedPack();
         if (cachedPack != null) {
-            cachedPack.get(chunkData, offset, chunkData.length);
+            cachedPack.position(offset);
+            cachedPack.get(chunkData, 0, chunkData.length);
             return chunkData;
         }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23135761/121189839-2acffc80-c873-11eb-8cf9-8a16b41488cf.png)
 