### PR TITLE
Added support for ScriptCustomEventPacket and added PluginMessageEvent

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/event/defaults/PluginMessageEvent.java
+++ b/src/main/java/dev/waterdog/waterdogpe/event/defaults/PluginMessageEvent.java
@@ -1,0 +1,24 @@
+package dev.waterdog.waterdogpe.event.defaults;
+
+import com.google.common.io.ByteArrayDataInput;
+import dev.waterdog.waterdogpe.event.defaults.PlayerEvent;
+import dev.waterdog.waterdogpe.player.ProxiedPlayer;
+
+public class PluginMessageEvent extends PlayerEvent {
+    private final byte[] data;
+    private final String channel;
+
+    public PluginMessageEvent(ProxiedPlayer player, byte[] data, String channel) {
+        super(player);
+        this.data = data;
+        this.channel = channel;
+    }
+
+    public byte[] getData() {
+        return data != null ? data.clone() : null;
+    }
+
+    public String getChannel() {
+        return channel;
+    }
+}

--- a/src/main/java/dev/waterdog/waterdogpe/network/downstream/ConnectedDownstreamHandler.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/downstream/ConnectedDownstreamHandler.java
@@ -16,7 +16,9 @@
 package dev.waterdog.waterdogpe.network.downstream;
 
 import com.nukkitx.protocol.bedrock.packet.*;
+import dev.waterdog.waterdogpe.ProxyServer;
 import dev.waterdog.waterdogpe.event.defaults.FastTransferRequestEvent;
+import dev.waterdog.waterdogpe.event.defaults.PluginMessageEvent;
 import dev.waterdog.waterdogpe.event.defaults.PostTransferCompleteEvent;
 import dev.waterdog.waterdogpe.network.ServerInfo;
 import dev.waterdog.waterdogpe.network.rewrite.types.RewriteData;
@@ -24,6 +26,8 @@ import dev.waterdog.waterdogpe.network.session.ServerConnection;
 import dev.waterdog.waterdogpe.player.ProxiedPlayer;
 import dev.waterdog.waterdogpe.utils.exceptions.CancelSignalException;
 import dev.waterdog.waterdogpe.utils.types.TranslationContainer;
+
+import java.nio.charset.StandardCharsets;
 
 import static dev.waterdog.waterdogpe.player.PlayerRewriteUtils.*;
 
@@ -34,6 +38,13 @@ public class ConnectedDownstreamHandler extends AbstractDownstreamHandler {
     public ConnectedDownstreamHandler(ProxiedPlayer player, ServerConnection server) {
         super(player);
         this.server = server;
+    }
+
+    @Override
+    public boolean handle(ScriptCustomEventPacket packet){
+        byte[] data = packet.getData().getBytes(StandardCharsets.UTF_8);
+        ProxyServer.getInstance().getEventManager().callEvent(new PluginMessageEvent(player, data, packet.getEventName()));
+        throw CancelSignalException.CANCEL;
     }
 
     @Override

--- a/src/main/java/dev/waterdog/waterdogpe/network/protocol/codec/BedrockCodec313.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/protocol/codec/BedrockCodec313.java
@@ -94,6 +94,7 @@ public class BedrockCodec313 extends BedrockCodec {
         builder.registerPacket(SetScoreboardIdentityPacket.class, SetScoreboardIdentitySerializer_v291.INSTANCE, 112);
         builder.registerPacket(SetLocalPlayerAsInitializedPacket.class, SetLocalPlayerAsInitializedSerializer_v291.INSTANCE, 113);
         builder.registerPacket(NetworkStackLatencyPacket.class, NetworkStackLatencySerializer_v291.INSTANCE, 115);
+        builder.registerPacket(ScriptCustomEventPacket.class, ScriptCustomEventSerializer_v291.INSTANCE, 117);
         builder.registerPacket(LevelSoundEvent2Packet.class, LevelSoundEvent2Serializer_v313.INSTANCE, 120);
         builder.registerPacket(NetworkChunkPublisherUpdatePacket.class, NetworkChunkPublisherUpdateSerializer_v313.INSTANCE, 121);
     }


### PR DESCRIPTION
This pull request adds PluginMessageEvent for plugins to use without changing their code on downstream servers.
Without this changes if downstream server sents a ScriptCustomEventPacket client will send violation warning and Disconnect.
