### PR TITLE
Implement modular forced host logic

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
@@ -77,7 +77,9 @@ public class ProxyServer {
 
     private IReconnectHandler reconnectHandler;
     private IJoinHandler joinHandler;
-    private ProxyListenerInterface proxyListener = new ProxyListenerInterface(){};
+    private IForcedHostHandler forcedHostHandler;
+    private ProxyListenerInterface proxyListener = new ProxyListenerInterface() {
+    };
 
     private final ScheduledExecutorService tickExecutor;
     private ScheduledFuture<?> tickFuture;
@@ -123,6 +125,7 @@ public class ProxyServer {
         this.configurationManager.loadLanguage();
         // Default Handlers
         this.reconnectHandler = new VanillaReconnectHandler();
+        this.forcedHostHandler = new VanillaForcedHostHandler();
         this.joinHandler = new VanillaJoinHandler(this);
         this.pluginManager = new PluginManager(this);
         this.configurationManager.loadServerInfos(this.serverInfoMap);
@@ -327,6 +330,7 @@ public class ProxyServer {
 
     /**
      * Allows to add servers dynamically to server map
+     *
      * @return if server was registered
      */
     public boolean registerServerInfo(ServerInfo serverInfo) {
@@ -336,6 +340,7 @@ public class ProxyServer {
 
     /**
      * Remove server from server map
+     *
      * @return removed ServerInfo or null
      */
     public ServerInfo removeServerInfo(String serverName) {
@@ -350,6 +355,7 @@ public class ProxyServer {
 
     /**
      * Get ServerInfo by address and port
+     *
      * @return ServerInfo instance of matched server
      */
     public ServerInfo getServerInfo(String address, int port) {
@@ -364,6 +370,7 @@ public class ProxyServer {
 
     /**
      * Get ServerInfo instance using hostname
+     *
      * @return ServerInfo assigned to forced host
      */
     public ServerInfo getForcedHost(String serverHostname) {
@@ -374,6 +381,7 @@ public class ProxyServer {
 
     /**
      * Get all registered ServerInfo instances
+     *
      * @return an unmodifiable collection containing all registered ServerInfo instances
      */
     public Collection<ServerInfo> getServers() {
@@ -431,6 +439,14 @@ public class ProxyServer {
 
     public IReconnectHandler getReconnectHandler() {
         return this.reconnectHandler;
+    }
+
+    public IForcedHostHandler getForcedHostHandler() {
+        return forcedHostHandler;
+    }
+
+    public void setForcedHostHandler(IForcedHostHandler forcedHostHandler) {
+        this.forcedHostHandler = forcedHostHandler;
     }
 
     public void setReconnectHandler(IReconnectHandler reconnectHandler) {

--- a/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
@@ -30,7 +30,6 @@ import dev.waterdog.waterdogpe.ProxyServer;
 import dev.waterdog.waterdogpe.command.CommandSender;
 import dev.waterdog.waterdogpe.event.defaults.*;
 import dev.waterdog.waterdogpe.logger.MainLogger;
-import dev.waterdog.waterdogpe.network.bridge.UpstreamBridge;
 import dev.waterdog.waterdogpe.network.serverinfo.ServerInfo;
 import dev.waterdog.waterdogpe.network.protocol.ProtocolVersion;
 import dev.waterdog.waterdogpe.network.rewrite.RewriteMaps;
@@ -160,7 +159,7 @@ public class ProxiedPlayer implements CommandSender {
             }
 
             // Determine forced host first
-            ServerInfo initialServer = this.proxy.getForcedHost(this.loginData.getJoinHostname());
+            ServerInfo initialServer = this.proxy.getForcedHostHandler().resolveForcedHost(this.loginData.getJoinHostname(), this);
             if (initialServer == null) {
                 initialServer = this.proxy.getJoinHandler().determineServer(this);
             }

--- a/src/main/java/dev/waterdog/waterdogpe/utils/types/IForcedHostHandler.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/types/IForcedHostHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 WaterdogTEAM
+ * Licensed under the GNU General Public License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.waterdog.waterdogpe.utils.types;
+
+import dev.waterdog.waterdogpe.network.serverinfo.ServerInfo;
+import dev.waterdog.waterdogpe.player.ProxiedPlayer;
+
+public interface IForcedHostHandler {
+
+    /**
+     * This handler can be overwritten to implement custom forced-host handler logic.
+     * @param domain The domain used in Minecraft's "Address" tab when connecting
+     * @param player The player object of the player that tried to join
+     * @return A ServerInfo object of the server that player should be moved to, or null if it should use priorities instead
+     */
+    ServerInfo resolveForcedHost(String domain, ProxiedPlayer player);
+}

--- a/src/main/java/dev/waterdog/waterdogpe/utils/types/VanillaForcedHostHandler.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/types/VanillaForcedHostHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 WaterdogTEAM
+ * Licensed under the GNU General Public License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.waterdog.waterdogpe.utils.types;
+
+import dev.waterdog.waterdogpe.network.serverinfo.ServerInfo;
+import dev.waterdog.waterdogpe.player.ProxiedPlayer;
+
+public class VanillaForcedHostHandler implements IForcedHostHandler {
+    @Override
+    public ServerInfo resolveForcedHost(String domain, ProxiedPlayer player) {
+        // Determine forced host first
+        return player.getProxy().getForcedHost(domain);
+    }
+}


### PR DESCRIPTION
This PR aims to implement a modular forced host approach. By default the config values will be used, but this can be extended to for example resolve a server from a group of servers.

Developers are able to implement the IForcedHostHandler interface and the included resolveForcedHost method. 
They can then set their own handler on plugin startup using ProxyServer#setForcedHostHandler(handler).

This uses the same design as the fallback & join handlers.