### PR TITLE
Implement split pack enforcement logic

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/packs/PackManager.java
+++ b/src/main/java/dev/waterdog/waterdogpe/packs/PackManager.java
@@ -146,9 +146,8 @@ public class PackManager {
     }
 
     public void rebuildPackets() {
-        boolean forcePacks = this.proxy.getConfiguration().forcePacks();
-        this.packsInfoPacket.setForcedToAccept(forcePacks);
-        this.stackPacket.setForcedToAccept(forcePacks);
+        this.packsInfoPacket.setForcedToAccept(this.proxy.getConfiguration().isForceServerPacks());
+        this.stackPacket.setForcedToAccept(this.proxy.getConfiguration().isOverwriteClientPacks());
 
         this.packsInfoPacket.getBehaviorPackInfos().clear();
         this.packsInfoPacket.getResourcePackInfos().clear();

--- a/src/main/java/dev/waterdog/waterdogpe/utils/config/ProxyConfig.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/config/ProxyConfig.java
@@ -130,9 +130,13 @@ public class ProxyConfig extends YamlConfig {
     @Comment("Enable/Disable the resource pack system")
     private boolean enableResourcePacks = true;
 
-    @Path("force_apply_packs")
+    @Path("overwrite_client_packs")
     @Comment("If this is enabled, the client will not be able to use custom packs")
-    private boolean forcePacks = false;
+    private boolean overwriteClientPacks = false;
+
+    @Path("force_server_packs")
+    @Comment("If enabled, the client will be forced to accept server-sided resource packs")
+    private boolean forceServerPacks = false;
 
     @Path("pack_cache_size")
     @Comment("You can set maximum pack size in MB to be cached.")
@@ -266,12 +270,20 @@ public class ProxyConfig extends YamlConfig {
         return this.enableResourcePacks;
     }
 
-    public void setForcePacks(boolean forcePacks) {
-        this.forcePacks = forcePacks;
+    public boolean isOverwriteClientPacks() {
+        return overwriteClientPacks;
     }
 
-    public boolean forcePacks() {
-        return this.forcePacks;
+    public void setOverwriteClientPacks(boolean overwriteClientPacks) {
+        this.overwriteClientPacks = overwriteClientPacks;
+    }
+
+    public void setForceServerPacks(boolean forceServerPacks) {
+        this.forceServerPacks = forceServerPacks;
+    }
+
+    public boolean isForceServerPacks() {
+        return forceServerPacks;
     }
 
     public int getPackCacheSize() {


### PR DESCRIPTION
The current configuration enforces the same toggle for the enforcePack option in **both** the ResourceStackPacket as well as the PacksInfoPacket. While the options are similarly named, the have different effects.

When enabling packEnforcing on the StackPacket, the client-sided resource packs will be entirely disabled.
When enabling packEnforcing on the PacksInfoPacket, the client does not leave the choice whether to accept the resource pack or not.

This PR fixes said issue by splitting the config option into two separate configuration options: isForceServerPacks and isOverwriteClientPacks. 

