### PR TITLE
Implement metadata rewrite

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/network/rewrite/EntityMap.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/rewrite/EntityMap.java
@@ -16,6 +16,7 @@
 package dev.waterdog.waterdogpe.network.rewrite;
 
 import com.nukkitx.protocol.bedrock.BedrockPacket;
+import com.nukkitx.protocol.bedrock.data.entity.EntityData;
 import com.nukkitx.protocol.bedrock.data.entity.EntityLinkData;
 import com.nukkitx.protocol.bedrock.handler.BedrockPacketHandler;
 import com.nukkitx.protocol.bedrock.packet.*;
@@ -87,6 +88,9 @@ public class EntityMap implements BedrockPacketHandler {
     @Override
     public boolean handle(SetEntityDataPacket packet) {
         packet.setRuntimeEntityId(PlayerRewriteUtils.rewriteId(packet.getRuntimeEntityId(), rewrite.getEntityId(), this.rewrite.getOriginalEntityId()));
+
+        PlayerRewriteUtils.rewriteEntityMetadata(packet.getMetadata(), this.rewrite.getEntityId(), this.rewrite.getOriginalEntityId());
+
         return true;
     }
 

--- a/src/main/java/dev/waterdog/waterdogpe/network/rewrite/EntityMap.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/rewrite/EntityMap.java
@@ -88,9 +88,7 @@ public class EntityMap implements BedrockPacketHandler {
     @Override
     public boolean handle(SetEntityDataPacket packet) {
         packet.setRuntimeEntityId(PlayerRewriteUtils.rewriteId(packet.getRuntimeEntityId(), rewrite.getEntityId(), this.rewrite.getOriginalEntityId()));
-
         PlayerRewriteUtils.rewriteEntityMetadata(packet.getMetadata(), this.rewrite.getEntityId(), this.rewrite.getOriginalEntityId());
-
         return true;
     }
 
@@ -116,6 +114,8 @@ public class EntityMap implements BedrockPacketHandler {
     public boolean handle(AddPlayerPacket packet) {
         packet.setRuntimeEntityId(PlayerRewriteUtils.rewriteId(packet.getRuntimeEntityId(), this.rewrite.getEntityId(), this.rewrite.getOriginalEntityId()));
         packet.setUniqueEntityId(PlayerRewriteUtils.rewriteId(packet.getUniqueEntityId(), this.rewrite.getEntityId(), this.rewrite.getOriginalEntityId()));
+        // Currently unused, but don't forget about this
+        // PlayerRewriteUtils.rewriteEntityMetadata(packet.getMetadata(), this.rewrite.getEntityId(), this.rewrite.getOriginalEntityId());
 
         ListIterator<EntityLinkData> iterator = packet.getEntityLinks().listIterator();
         while (iterator.hasNext()) {
@@ -133,6 +133,8 @@ public class EntityMap implements BedrockPacketHandler {
     public boolean handle(AddEntityPacket packet) {
         packet.setRuntimeEntityId(PlayerRewriteUtils.rewriteId(packet.getRuntimeEntityId(), this.rewrite.getEntityId(), this.rewrite.getOriginalEntityId()));
         packet.setUniqueEntityId(PlayerRewriteUtils.rewriteId(packet.getUniqueEntityId(), this.rewrite.getEntityId(), this.rewrite.getOriginalEntityId()));
+        // Currently unused, but don't forget about this
+        // PlayerRewriteUtils.rewriteEntityMetadata(packet.getMetadata(), this.rewrite.getEntityId(), this.rewrite.getOriginalEntityId());
 
         ListIterator<EntityLinkData> iterator = packet.getEntityLinks().listIterator();
         while (iterator.hasNext()) {
@@ -150,6 +152,8 @@ public class EntityMap implements BedrockPacketHandler {
     public boolean handle(AddItemEntityPacket packet) {
         packet.setRuntimeEntityId(PlayerRewriteUtils.rewriteId(packet.getRuntimeEntityId(), this.rewrite.getEntityId(), this.rewrite.getOriginalEntityId()));
         packet.setUniqueEntityId(PlayerRewriteUtils.rewriteId(packet.getUniqueEntityId(), this.rewrite.getEntityId(), this.rewrite.getOriginalEntityId()));
+        // Currently unused, but don't forget about this
+        // PlayerRewriteUtils.rewriteEntityMetadata(packet.getMetadata(), this.rewrite.getEntityId(), this.rewrite.getOriginalEntityId());
         return true;
     }
 

--- a/src/main/java/dev/waterdog/waterdogpe/player/PlayerRewriteUtils.java
+++ b/src/main/java/dev/waterdog/waterdogpe/player/PlayerRewriteUtils.java
@@ -84,17 +84,16 @@ public class PlayerRewriteUtils {
         return from == origin ? rewritten : (from == rewritten ? origin : from);
     }
 
-    public static void rewriteEntityMetadata(EntityDataMap entityDataMap, long entityId, long originalEntityId){
+    public static void rewriteEntityMetadata(EntityDataMap entityDataMap, long entityId, long originalEntityId) {
         rewriteEntityProperty(entityDataMap, EntityData.TARGET_EID, entityId, originalEntityId);
         rewriteEntityProperty(entityDataMap, EntityData.OWNER_EID, entityId, originalEntityId);
         rewriteEntityProperty(entityDataMap, EntityData.TRADE_TARGET_EID, entityId, originalEntityId);
         rewriteEntityProperty(entityDataMap, EntityData.LEASH_HOLDER_EID, entityId, originalEntityId);
     }
 
-    public static void rewriteEntityProperty(EntityDataMap map, EntityData targetEntry, long entityId, long originalEntityId){
-        long currentId = map.getLong(targetEntry);
-        if(currentId != 0L){
-            map.replace(targetEntry, rewriteId(currentId, entityId, originalEntityId));
+    public static void rewriteEntityProperty(EntityDataMap map, EntityData targetEntry, long entityId, long originalEntityId) {
+        if(map.containsKey(targetEntry)) {
+            map.replace(targetEntry, rewriteId(map.getLong(targetEntry), entityId, originalEntityId));
         }
     }
 

--- a/src/main/java/dev/waterdog/waterdogpe/player/PlayerRewriteUtils.java
+++ b/src/main/java/dev/waterdog/waterdogpe/player/PlayerRewriteUtils.java
@@ -84,6 +84,20 @@ public class PlayerRewriteUtils {
         return from == origin ? rewritten : (from == rewritten ? origin : from);
     }
 
+    public static void rewriteEntityMetadata(EntityDataMap entityDataMap, long entityId, long originalEntityId){
+        rewriteEntityProperty(entityDataMap, EntityData.TARGET_EID, entityId, originalEntityId);
+        rewriteEntityProperty(entityDataMap, EntityData.OWNER_EID, entityId, originalEntityId);
+        rewriteEntityProperty(entityDataMap, EntityData.TRADE_TARGET_EID, entityId, originalEntityId);
+        rewriteEntityProperty(entityDataMap, EntityData.LEASH_HOLDER_EID, entityId, originalEntityId);
+    }
+
+    public static void rewriteEntityProperty(EntityDataMap map, EntityData targetEntry, long entityId, long originalEntityId){
+        long currentId = map.getLong(targetEntry);
+        if(currentId != 0L){
+            map.replace(targetEntry, rewriteId(currentId, entityId, originalEntityId));
+        }
+    }
+
     public static int determineDimensionId(int from, int to) {
         if (from == to) {
             return from == DIMENSION_OVERWORLD ? DIMENSION_NETHER : DIMENSION_OVERWORLD;


### PR DESCRIPTION
Currently, we only rewrite entityIds that are actual packet properties. However, we do not rewrite entityIds sent as a part of the SetActorDataPacket, leading to issues like #152.

This PR resolves #152.

Note: @Alemiz112 I don't know whether the rewrites for the other metadata flags are correct since my protocol knowledge in this area is limited, please correct me if I got some of them wrong.

