### PR TITLE
Pass ThreadedExecutor to event futures

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/event/EventHandler.java
+++ b/src/main/java/dev/waterdog/waterdogpe/event/EventHandler.java
@@ -57,7 +57,7 @@ public class EventHandler {
                 this.handlePriority(priority, event);
             }
             return event;
-        }).thenAccept(futureEvent -> futureEvent.completeFuture(future)).whenComplete((ignore, error) -> {
+        }, this.eventManager.getThreadedExecutor()).thenAccept(futureEvent -> futureEvent.completeFuture(future)).whenComplete((ignore, error) -> {
             if (error != null && !future.isDone()) {
                 future.completeExceptionally(error);
                 ProxyServer.getInstance().getLogger().error("Exception was thrown in event handler", error);


### PR DESCRIPTION
I believe that this was not intended. During late-night research, I found that the ExecutorService created in the EventManager is actually not used anywhere. 

This should fix that issue.
This also explains why when thread profiling, I have always seen the event executor threads to be completely idling.

