### PR TITLE
Enable Education features by default

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/utils/config/ProxyConfig.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/config/ProxyConfig.java
@@ -124,7 +124,7 @@ public class ProxyConfig extends YamlConfig {
 
     @Path("enable_edu_features")
     @Comment("Education features require small adjustments to work correctly. Enable this option if any of downstream servers support education features.")
-    private boolean enableEducationFeatures = false;
+    private boolean enableEducationFeatures = true;
 
     @Path("enable_packs")
     @Comment("Enable/Disable the resource pack system")


### PR DESCRIPTION
Most of the server software used by users (especially PM) supports education items/blocks. However, some users do experience client crashes when using WaterdogPE without enable_edu_features enabled. I think enabling enable_edu_features by default shouldn't be a problem at all.