### PR TITLE
Implement basic metrics interface

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
@@ -81,6 +81,7 @@ public class ProxyServer {
     private IReconnectHandler reconnectHandler;
     private IJoinHandler joinHandler;
     private IForcedHostHandler forcedHostHandler;
+    private IMetricsHandler metricsHandler;
     private ProxyListenerInterface proxyListener = new ProxyListenerInterface(){};
 
     private final EventLoopGroup bossEventLoopGroup;
@@ -150,6 +151,7 @@ public class ProxyServer {
         // Default Handlers
         this.reconnectHandler = new VanillaReconnectHandler();
         this.forcedHostHandler = new VanillaForcedHostHandler();
+        this.metricsHandler = new VanillaMetricsHandler();
         this.joinHandler = new VanillaJoinHandler(this);
         this.pluginManager = new PluginManager(this);
         this.configurationManager.loadServerInfos(this.serverInfoMap);
@@ -471,6 +473,14 @@ public class ProxyServer {
 
     public void setForcedHostHandler(IForcedHostHandler forcedHostHandler) {
         this.forcedHostHandler = forcedHostHandler;
+    }
+
+    public IMetricsHandler getMetricsHandler() {
+        return metricsHandler;
+    }
+
+    public void setMetricsHandler(IMetricsHandler metricsHandler) {
+        this.metricsHandler = metricsHandler;
     }
 
     public void setReconnectHandler(IReconnectHandler reconnectHandler) {

--- a/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
@@ -480,6 +480,7 @@ public class ProxyServer {
     }
 
     public void setMetricsHandler(IMetricsHandler metricsHandler) {
+        Preconditions.checkNotNull(metricsHandler, "You cannot set the metricsHandler to null!");
         this.metricsHandler = metricsHandler;
     }
 

--- a/src/main/java/dev/waterdog/waterdogpe/network/bridge/ProxyBatchBridge.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/bridge/ProxyBatchBridge.java
@@ -71,6 +71,12 @@ public abstract class ProxyBatchBridge {
             this.sendWrapped(buf, this.isEncrypted());
         }
 
+        if (changed) {
+            player.getProxy().getMetricsHandler().changedBatch();
+        } else {
+            player.getProxy().getMetricsHandler().unchangedBatch();
+        }
+
         // Packets from array aren't used so we can deallocate whole.
         this.deallocatePackets(allPackets);
     }

--- a/src/main/java/dev/waterdog/waterdogpe/network/bridge/TransferBatchBridge.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/bridge/TransferBatchBridge.java
@@ -71,6 +71,7 @@ public class TransferBatchBridge extends AbstractDownstreamBatchBridge {
             this.player.disconnect("Transfer packet queue got too large!");
             // Deallocate packet queue manually because result of TransferBatchBridge#release called
             // from disconnect handler can be ignored as BatchHandler can be already changed.
+            player.getProxy().getMetricsHandler().packetQueueTooLarge();
             this.free();
             return;
         }

--- a/src/main/java/dev/waterdog/waterdogpe/utils/types/IMetricsHandler.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/types/IMetricsHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 WaterdogTEAM
+ * Licensed under the GNU General Public License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.waterdog.waterdogpe.utils.types;
+
+/**
+ * This interface can be used to record and display WaterdogPE-Internal metrics.
+ */
+public interface IMetricsHandler {
+
+    /**
+     * Called once for every batch handled by the ProxyBatchBridge which has been rewritten
+     */
+    public void changedBatch();
+
+    /**
+     * Called once for every batch handled by the ProxyBatchBridge which has not been rewritten
+     */
+    public void unchangedBatch();
+
+    /**
+     * Triggered when the packet queue of the TransferBatchBridge becomes too large and the player gets disconnected
+     */
+    public void packetQueueTooLarge();
+}

--- a/src/main/java/dev/waterdog/waterdogpe/utils/types/VanillaMetricsHandler.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/types/VanillaMetricsHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 WaterdogTEAM
+ * Licensed under the GNU General Public License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.waterdog.waterdogpe.utils.types;
+
+public class VanillaMetricsHandler implements IMetricsHandler {
+    @Override
+    public void changedBatch() {
+
+    }
+
+    @Override
+    public void unchangedBatch() {
+
+    }
+
+    @Override
+    public void packetQueueTooLarge() {
+
+    }
+}


### PR DESCRIPTION
This PR implements a basic metrics interface with some metric functions that can be used to draw graphs and collect statistics.

For now the implemented metrics are (un)changed batches and packet queue exhaustion. Room for more though.

No API breaks included, completely BC. 
The IMetricsInterface has the default NOOP implementation in the VanillaMetricsInterface.


