### PR TITLE
LoginUpstreamHandler: Close session if session didn't closed

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/network/upstream/LoginUpstreamHandler.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/upstream/LoginUpstreamHandler.java
@@ -50,7 +50,9 @@ public class LoginUpstreamHandler implements BedrockPacketHandler {
 
     private void onLoginFailed(boolean xboxAuth, Throwable throwable, String disconnectReason) {
         String message = this.proxy.getProxyListener().onLoginFailed(this.session.getAddress(), xboxAuth, throwable, disconnectReason);
-        this.session.disconnect(message);
+        if (!this.session.isClosed()) {
+            this.session.disconnect(message);
+        }
     }
 
     @Override


### PR DESCRIPTION
This can prevent errors when a player disconnected while login sequence, such as:

```
15:26:16 [WARN ] A task raised an exception. Task: com.nukkitx.protocol.bedrock.BedrockRakNetSessionListener$$Lambda$607/0x00000000cc049f60@c236ac7c
java.lang.IllegalStateException: Connection has been closed
        at com.nukkitx.protocol.bedrock.BedrockSession.checkForClosed(BedrockSession.java:86) ~[Waterdog.jar:?]
        at com.nukkitx.protocol.bedrock.BedrockSession.checkPacket(BedrockSession.java:105) ~[Waterdog.jar:?]
        at com.nukkitx.protocol.bedrock.BedrockSession.sendPacketImmediately(BedrockSession.java:99) ~[Waterdog.jar:?]
        at com.nukkitx.protocol.bedrock.BedrockServerSession.disconnect0(BedrockServerSession.java:60) ~[Waterdog.jar:?]
        at com.nukkitx.protocol.bedrock.BedrockServerSession.disconnect(BedrockServerSession.java:30) ~[Waterdog.jar:?]
        at com.nukkitx.protocol.bedrock.BedrockServerSession.disconnect(BedrockServerSession.java:24) ~[Waterdog.jar:?]
        at dev.waterdog.waterdogpe.network.upstream.LoginUpstreamHandler.onLoginFailed(LoginUpstreamHandler.java:53) ~[Waterdog.jar:?]
        at dev.waterdog.waterdogpe.network.upstream.LoginUpstreamHandler.handle(LoginUpstreamHandler.java:122) ~[Waterdog.jar:?]
        at com.nukkitx.protocol.bedrock.packet.LoginPacket.handle(LoginPacket.java:21) ~[Waterdog.jar:?]
        at com.nukkitx.protocol.bedrock.handler.DefaultBatchHandler.handle(DefaultBatchHandler.java:29) ~[Waterdog.jar:?]
        at com.nukkitx.protocol.bedrock.BedrockSession.onWrappedPacket(BedrockSession.java:284) ~[Waterdog.jar:?]
        at com.nukkitx.protocol.bedrock.BedrockRakNetSessionListener.lambda$onEncapsulated$0(BedrockRakNetSessionListener.java:39) ~[Waterdog.jar:?]
        at com.nukkitx.protocol.bedrock.BedrockRakNetSessionListener$$Lambda$607/0x00000000cc049f60.run(Unknown Source) ~[?:?]
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) ~[Waterdog.jar:?]
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469) ~[Waterdog.jar:?]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:384) ~[Waterdog.jar:?]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) ~[Waterdog.jar:?]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[Waterdog.jar:?]
        at java.lang.Thread.run(Thread.java:884) [?:?]
```

I don't know how to reproduce this exactly, but It keeps happening to me.