### PR TITLE
Add InitialServerConnectedEvent to record initial, successful server connections

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/event/defaults/InitialServerConnectedEvent.java
+++ b/src/main/java/dev/waterdog/waterdogpe/event/defaults/InitialServerConnectedEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 WaterdogTEAM
+ * Licensed under the GNU General Public License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.waterdog.waterdogpe.event.defaults;
+
+import dev.waterdog.waterdogpe.event.AsyncEvent;
+import dev.waterdog.waterdogpe.network.session.DownstreamClient;
+import dev.waterdog.waterdogpe.player.ProxiedPlayer;
+
+/**
+ * Called when a player successfully logged in to the initial server. This event is not called when the transfer from
+ * one server to another completed successfully, use {@link TransferCompleteEvent} for that purpose instead. At this
+ * point the player associated with the event is already logged in and registered to the initial downstream.
+ */
+@AsyncEvent
+public class InitialServerConnectedEvent extends PlayerEvent {
+
+    private final DownstreamClient initialDownstream;
+
+    public InitialServerConnectedEvent(ProxiedPlayer player, DownstreamClient initialDownstream) {
+        super(player);
+        this.initialDownstream = initialDownstream;
+    }
+
+    public DownstreamClient getInitialDownstream() {
+        return this.initialDownstream;
+    }
+}

--- a/src/main/java/dev/waterdog/waterdogpe/network/downstream/InitialHandler.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/downstream/InitialHandler.java
@@ -18,6 +18,7 @@ package dev.waterdog.waterdogpe.network.downstream;
 import com.nimbusds.jwt.SignedJWT;
 import com.nukkitx.protocol.bedrock.packet.*;
 import com.nukkitx.protocol.bedrock.util.EncryptionUtils;
+import dev.waterdog.waterdogpe.event.defaults.InitialServerConnectedEvent;
 import dev.waterdog.waterdogpe.network.serverinfo.ServerInfo;
 import dev.waterdog.waterdogpe.network.protocol.ProtocolVersion;
 import dev.waterdog.waterdogpe.network.rewrite.BlockMap;
@@ -123,7 +124,10 @@ public class InitialHandler extends AbstractDownstreamHandler {
 
         int blockingId = client.getSession().getHardcodedBlockingId();
         this.player.getUpstream().getHardcodedBlockingId().set(blockingId);
+
         this.client.getSession().onInitialServerConnected(player);
+        this.player.getProxy().getEventManager().callEvent(new InitialServerConnectedEvent(this.player, this.client));
+
         return true;
     }
 }


### PR DESCRIPTION
I'm trying to mark a player as "logged in" after he successfully connected to the first downstream server. While (for example) Velocity calls the `ServerConnectedEvent` with a `null` previous server, I thought leaving the transfer event as-is might be the better option here, as it does not break backwards compatibilty (for example assuming the old downstream is always non-null), and makes it easier to listen only for one of the events.

The name is choosen based off the `InitialServerDeterminationEvent` to stay consistent with the naming.