### PR TITLE
feat: update ServerInfo.matchAddress to check both IPv4 and hostName

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/network/serverinfo/ServerInfo.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/serverinfo/ServerInfo.java
@@ -70,9 +70,9 @@ public abstract class ServerInfo {
         InetAddress inetAddress = this.publicAddress.getAddress();
         boolean addressMatch;
         if (inetAddress == null) {
-            addressMatch = this.publicAddress.getHostName().equals(address);
+            addressMatch = (this.publicAddress.getHostString().equals(address) || this.publicAddress.getHostName().equals(address));
         } else {
-            addressMatch = inetAddress.getHostName().equals(address);
+            addressMatch = (inetAddress.getHostAddress().equals(address) || inetAddress.getHostName().equals(address));
         }
         return addressMatch && this.publicAddress.getPort() == port;
     }


### PR DESCRIPTION
This is useful when servers use pure IPv4 in TransferPacket