### PR TITLE
[BC Break] Allow plugins to add multiple (up/down)stream handlers

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/network/bridge/DownstreamBridge.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/bridge/DownstreamBridge.java
@@ -21,7 +21,7 @@ import com.nukkitx.protocol.bedrock.handler.BedrockPacketHandler;
 import dev.waterdog.waterdogpe.network.rewrite.RewriteMaps;
 import dev.waterdog.waterdogpe.player.ProxiedPlayer;
 import dev.waterdog.waterdogpe.utils.exceptions.CancelSignalException;
-import java.util.concurrent.atomic.AtomicBoolean;
+import dev.waterdog.waterdogpe.utils.types.PacketHandler;
 
 /**
  * This is the downstream implementation of the {@link AbstractDownstreamBatchBridge} which is used after initial connection initialization or
@@ -41,14 +41,14 @@ public class DownstreamBridge extends AbstractDownstreamBatchBridge {
         RewriteMaps rewriteMaps = this.player.getRewriteMaps();
         boolean rewroteBlock = rewriteMaps.getBlockMap() != null && rewriteMaps.getBlockMap().doRewrite(packet);
 
-        AtomicBoolean pluginHandled = new AtomicBoolean(false);
+        boolean pluginHandled = false;
         if (!this.player.getPluginDownstreamHandlers().isEmpty()) {
-            this.player.getPluginDownstreamHandlers().forEach(pluginHandler -> {
+            for (PacketHandler pluginHandler : this.player.getPluginDownstreamHandlers()) {
                 if (pluginHandler.handlePacket(packet)) {
-                    pluginHandled.set(true);
+                    pluginHandled = true;
                 }
-            });
+            }
         }
-        return changed || rewroteBlock || pluginHandled.get();
+        return changed || rewroteBlock || pluginHandled;
     }
 }

--- a/src/main/java/dev/waterdog/waterdogpe/network/bridge/UpstreamBridge.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/bridge/UpstreamBridge.java
@@ -26,7 +26,6 @@ import dev.waterdog.waterdogpe.utils.types.PacketHandler;
 import io.netty.buffer.ByteBuf;
 
 import java.util.Collection;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This is the default upstream to downstream implementation of BatchBridge which is used during all life cycles of the connection.

--- a/src/main/java/dev/waterdog/waterdogpe/network/bridge/UpstreamBridge.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/bridge/UpstreamBridge.java
@@ -22,6 +22,7 @@ import com.nukkitx.protocol.bedrock.handler.BedrockPacketHandler;
 import dev.waterdog.waterdogpe.network.session.DownstreamSession;
 import dev.waterdog.waterdogpe.player.ProxiedPlayer;
 import dev.waterdog.waterdogpe.utils.exceptions.CancelSignalException;
+import dev.waterdog.waterdogpe.utils.types.PacketHandler;
 import io.netty.buffer.ByteBuf;
 
 import java.util.Collection;
@@ -66,14 +67,14 @@ public class UpstreamBridge extends ProxyBatchBridge implements BatchHandler {
     @Override
     public boolean handlePacket(BedrockPacket packet, BedrockPacketHandler handler) throws CancelSignalException {
         boolean changed = super.handlePacket(packet, handler);
-        AtomicBoolean pluginHandled = new AtomicBoolean(false);
+        boolean pluginHandled = false;
         if (!this.player.getPluginUpstreamHandlers().isEmpty()) {
-            this.player.getPluginUpstreamHandlers().forEach(pluginHandler -> {
+            for (PacketHandler pluginHandler : this.player.getPluginUpstreamHandlers()) {
                 if (pluginHandler.handlePacket(packet)) {
-                    pluginHandled.set(true);
+                    pluginHandled = true;
                 }
-            });
+            }
         }
-        return changed || pluginHandled.get();
+        return changed || pluginHandled;
     }
 }

--- a/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
@@ -48,6 +48,7 @@ import it.unimi.dsi.fastutil.objects.*;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -106,8 +107,8 @@ public class ProxiedPlayer implements CommandSender {
      * Additional downstream and upstream handlers can be set by plugin.
      * Do not set directly BedrockPacketHandler to sessions!
      */
-    private PacketHandler pluginUpstreamHandler = null;
-    private PacketHandler pluginDownstreamHandler = null;
+    private final List<PacketHandler> pluginUpstreamHandlers = new ObjectArrayList<>();
+    private final List<PacketHandler> pluginDownstreamHandlers = new ObjectArrayList<>();
 
     public ProxiedPlayer(ProxyServer proxy, BedrockServerSession session, LoginData loginData) {
         this.proxy = proxy;
@@ -795,24 +796,48 @@ public class ProxiedPlayer implements CommandSender {
         return this.entityLinks;
     }
 
-    public PacketHandler getPluginUpstreamHandler() {
-        return this.pluginUpstreamHandler;
+    /**
+     * This method is deprecated. Please use {@link #getPluginUpstreamHandlers()} instead.
+     */
+    @Deprecated()
+    public List<PacketHandler> getPluginUpstreamHandler() {
+        return this.pluginUpstreamHandlers;
+    }
+
+    public List<PacketHandler> getPluginUpstreamHandlers() {
+        return this.pluginUpstreamHandlers;
     }
 
     public LongSet getChunkBlobs() {
         return this.chunkBlobs;
     }
 
+    /**
+     * This method is deprecated. Please use {@link #getPluginDownstreamHandlers()}.add() instead.
+     */
+    @Deprecated()
     public void setPluginUpstreamHandler(PacketHandler pluginUpstreamHandler) {
-        this.pluginUpstreamHandler = pluginUpstreamHandler;
+        this.pluginUpstreamHandlers.add(pluginUpstreamHandler);
     }
 
-    public PacketHandler getPluginDownstreamHandler() {
-        return this.pluginDownstreamHandler;
+    /**
+     * This method is deprecated. Please use {@link #getPluginDownstreamHandlers()} instead.
+     */
+    @Deprecated()
+    public List<PacketHandler> getPluginDownstreamHandler() {
+        return this.pluginDownstreamHandlers;
     }
 
+    public List<PacketHandler> getPluginDownstreamHandlers() {
+        return this.pluginDownstreamHandlers;
+    }
+
+    /**
+     * This method is deprecated. Please use {@link #getPluginDownstreamHandlers()}.add() instead.
+     */
+    @Deprecated()
     public void setPluginDownstreamHandler(PacketHandler pluginDownstreamHandler) {
-        this.pluginDownstreamHandler = pluginDownstreamHandler;
+        this.pluginDownstreamHandlers.add(pluginDownstreamHandler);
     }
 
     public void setAcceptPlayStatus(boolean acceptPlayStatus) {

--- a/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
@@ -800,8 +800,8 @@ public class ProxiedPlayer implements CommandSender {
      * This method is deprecated. Please use {@link #getPluginUpstreamHandlers()} instead.
      */
     @Deprecated()
-    public List<PacketHandler> getPluginUpstreamHandler() {
-        return this.pluginUpstreamHandlers;
+    public PacketHandler getPluginUpstreamHandler() {
+        return this.pluginUpstreamHandlers.get(0);
     }
 
     public List<PacketHandler> getPluginUpstreamHandlers() {
@@ -824,8 +824,8 @@ public class ProxiedPlayer implements CommandSender {
      * This method is deprecated. Please use {@link #getPluginDownstreamHandlers()} instead.
      */
     @Deprecated()
-    public List<PacketHandler> getPluginDownstreamHandler() {
-        return this.pluginDownstreamHandlers;
+    public PacketHandler getPluginDownstreamHandler() {
+        return this.pluginDownstreamHandlers.get(0);
     }
 
     public List<PacketHandler> getPluginDownstreamHandlers() {


### PR DESCRIPTION
# Motivation

In the current WDPE design, we cannot have multiple upstream/downstream handlers. This can be problem when we use public plugin which calls `ProxiedPlayer#setUpsteramHandler()` and `ProxiedPlayer#setDownstreamHandler()`.

# API Changes

`ProxiedPlayer#setUpstreamHandler()` is now deprecated. Replaced with `ProxiedPlayer#getUpstreamHandlers().add()`.

`ProxiedPlayer#setDownstreamHandler()` is now deprecated. Replaced with `ProxiedPlayer#getDownstreamHandlers().add()`.

Added `ProxiedPlayer#getUpstreamHandlers()`.

Added `ProxiedPlayer#getDownstreamHandlers()`.

Deprecated `ProxiedPlayer#getDownstreamHandler()`.

Deprecated `ProxiedPlayer#getUpstreamHandler()`.

# Site Notes

Tbh, It seems it would be better to keep `ProxiedPlayer#setUpstreamHandler()` and `ProxiedPlayer#setDownstreamHandler()`.