### PR TITLE
Implement automated docker publishing

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -32,3 +32,16 @@ jobs:
           title: "Snapshot Build"
           files: |
             target/Waterdog.jar
+      - name: Login to DockerHub
+        if: github.ref == 'refs/heads/master'
+        uses: docker/login-action@v2
+        with:
+          username: waterdogpe
+          password: ${{ secrets.docker_pat }}
+      - name: Publish Docker latest
+        if: github.ref == 'refs/heads/master'
+        uses: docker/build-push-action@v3.1.1
+        with:
+          context: ./
+          push: true
+          tags: waterdogpe/waterdogpe:latest

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -26,3 +26,15 @@ jobs:
           title: "Release ${{ github.ref }} by ${{ github.actor }}"
           files: |
             target/Waterdog.jar
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: waterdogpe
+          password: ${{ secrets.docker_pat }}
+      - name: Publish Docker release
+        uses: docker/build-push-action@v3.1.1
+        with:
+          context: ./
+          push: true
+          tags: waterdogpe/waterdogpe:release,waterdogpe/waterdogpe:${{ github.ref }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:17-jdk-slim
+
+EXPOSE 19132/tcp
+EXPOSE 19132/udp
+
+WORKDIR /home
+
+ADD target/Waterdog.jar /home
+
+ENTRYPOINT ["java", "-jar", "Waterdog.jar"]


### PR DESCRIPTION
This should automatically publish the image to dockerhub. The intention of this is to add direct support for WDPE with the latest updates to the docker workspace, through an official channel.