### PR TITLE
Ensure FIFO ordering in SynchronousQueue

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/event/EventManager.java
+++ b/src/main/java/dev/waterdog/waterdogpe/event/EventManager.java
@@ -38,7 +38,7 @@ public class EventManager {
         ThreadFactoryBuilder builder = new ThreadFactoryBuilder();
         builder.setNameFormat("WaterdogEvents Executor");
         int idleThreads = this.proxy.getConfiguration().getIdleThreads();
-        this.threadedExecutor = new ThreadPoolExecutor(idleThreads, Integer.MAX_VALUE, 60, TimeUnit.SECONDS, new SynchronousQueue<>(), builder.build());
+        this.threadedExecutor = new ThreadPoolExecutor(idleThreads, Integer.MAX_VALUE, 60, TimeUnit.SECONDS, new SynchronousQueue<>(true), builder.build());
     }
 
     public <T extends Event> void subscribe(Class<T> event, Consumer<T> handler) {


### PR DESCRIPTION
## Introduction
By default, SynchronousQueue acts as Stack (LIFO). Only events on the top of a stack will be pop first, causing events to execute in the wrong order (i.e.: PlayerDisconnectEvent executes before PlayerLoginEvent because PDE is on top of the stack).

This commit changes the logic for SynchronousQueue to use an actual Queue instead of a Stack.