### PR TITLE
Fix 1.19.62 check again

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/network/upstream/LoginUpstreamHandler.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/upstream/LoginUpstreamHandler.java
@@ -156,6 +156,7 @@ public class LoginUpstreamHandler implements BedrockPacketHandler {
             }
 
             LoginData loginData = handshakeEntry.buildData(this.session, this.proxy);
+            this.session.setPacketCodec(loginData.getProtocol().getCodec());
             this.proxy.getLogger().info("[" + this.session.getAddress() + "|" + handshakeEntry.getDisplayName() + "] <-> Upstream has connected (protocol=" + loginData.getProtocol().getProtocol() + "version=" + loginData.getProtocol().getMinecraftVersion() +")");
 
             PlayerPreLoginEvent loginEvent = new PlayerPreLoginEvent(ProxiedPlayer.class, loginData, this.session.getAddress());

--- a/src/main/java/dev/waterdog/waterdogpe/player/HandshakeEntry.java
+++ b/src/main/java/dev/waterdog/waterdogpe/player/HandshakeEntry.java
@@ -32,7 +32,7 @@ public class HandshakeEntry {
     private final JsonObject clientData;
     private final JsonObject extraData;
     private final boolean xboxAuthed;
-    private final ProtocolVersion protocol;
+    private ProtocolVersion protocol;
 
     public HandshakeEntry(ECPublicKey identityPublicKey, JsonObject clientData, JsonObject extraData, boolean xboxAuthed, ProtocolVersion protocol) {
         this.identityPublicKey = identityPublicKey;
@@ -53,14 +53,12 @@ public class HandshakeEntry {
         builder.uuid(UUID.fromString(this.extraData.get("identity").getAsString()));
         builder.xuid(this.extraData.get("XUID").getAsString());
         builder.xboxAuthed(this.xboxAuthed);
-        builder.protocol(this.protocol);
         // Thank you Mojang: this version includes protocol changes, but protocol version was not increased.
         var gameVersion = getClientData().has("GameVersion") ? getClientData().get("GameVersion").getAsString().replaceAll("\n", "") : null;
         if (protocol.equals(ProtocolVersion.MINECRAFT_PE_1_19_60) && ProtocolVersion.MINECRAFT_PE_1_19_62.getMinecraftVersion().equals(gameVersion)) {
-            builder.protocol(ProtocolVersion.MINECRAFT_PE_1_19_62);
-            session.setPacketCodec(protocol.getCodec());
+            setProtocol(ProtocolVersion.MINECRAFT_PE_1_19_62);
         }
-
+        builder.protocol(this.protocol);
         builder.joinHostname(this.clientData.get("ServerAddress").getAsString().split(":")[0]);
         builder.address(session.getAddress());
         builder.keyPair(event.getKeyPair());
@@ -93,6 +91,10 @@ public class HandshakeEntry {
 
     public String getDisplayName() {
         return this.extraData.get("displayName").getAsString();
+    }
+
+    public void setProtocol(ProtocolVersion protocol) {
+        this.protocol = protocol;
     }
 
     public ProtocolVersion getProtocol() {


### PR DESCRIPTION
This fixes https://github.com/WaterdogPE/WaterdogPE/commit/29c997b67ab76b3a22457f3a5a014de180a5b66d which had issues with the upstream codec not being set correctly. Works with NPC's, supposed to work with multiple players but I could not test it right now. 