### PR TITLE
implement bugsnag anonymous error reporting (WIP)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.bugsnag</groupId>
+            <version>[3.0,4.0)</version>
+            <artifactId>bugsnag</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-base</artifactId>
             <version>3.0.1</version>

--- a/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
@@ -25,9 +25,13 @@ import dev.waterdog.waterdogpe.logger.MainLogger;
 import dev.waterdog.waterdogpe.network.EventLoops;
 import dev.waterdog.waterdogpe.network.NetworkMetrics;
 import dev.waterdog.waterdogpe.network.connection.codec.compression.CompressionAlgorithm;
-import dev.waterdog.waterdogpe.network.connection.codec.initializer.ProxiedServerSessionInitializer;
 import dev.waterdog.waterdogpe.network.connection.codec.initializer.OfflineServerChannelInitializer;
-import dev.waterdog.waterdogpe.network.connection.handler.*;
+import dev.waterdog.waterdogpe.network.connection.codec.initializer.ProxiedServerSessionInitializer;
+import dev.waterdog.waterdogpe.network.connection.codec.query.QueryHandler;
+import dev.waterdog.waterdogpe.network.connection.handler.DefaultForcedHostHandler;
+import dev.waterdog.waterdogpe.network.connection.handler.IForcedHostHandler;
+import dev.waterdog.waterdogpe.network.connection.handler.IJoinHandler;
+import dev.waterdog.waterdogpe.network.connection.handler.IReconnectHandler;
 import dev.waterdog.waterdogpe.network.protocol.ProtocolCodecs;
 import dev.waterdog.waterdogpe.network.protocol.ProtocolVersion;
 import dev.waterdog.waterdogpe.network.protocol.updaters.CodecUpdaterCommands;
@@ -37,16 +41,17 @@ import dev.waterdog.waterdogpe.packs.PackManager;
 import dev.waterdog.waterdogpe.player.PlayerManager;
 import dev.waterdog.waterdogpe.player.ProxiedPlayer;
 import dev.waterdog.waterdogpe.plugin.PluginManager;
-import dev.waterdog.waterdogpe.network.connection.codec.query.QueryHandler;
 import dev.waterdog.waterdogpe.scheduler.WaterdogScheduler;
 import dev.waterdog.waterdogpe.security.SecurityManager;
 import dev.waterdog.waterdogpe.utils.ConfigurationManager;
 import dev.waterdog.waterdogpe.utils.ThreadFactoryBuilder;
 import dev.waterdog.waterdogpe.utils.bstats.Metrics;
-import dev.waterdog.waterdogpe.utils.config.*;
+import dev.waterdog.waterdogpe.utils.config.LangConfig;
 import dev.waterdog.waterdogpe.utils.config.proxy.NetworkSettings;
 import dev.waterdog.waterdogpe.utils.config.proxy.ProxyConfig;
-import dev.waterdog.waterdogpe.utils.types.*;
+import dev.waterdog.waterdogpe.utils.reporting.ErrorReporting;
+import dev.waterdog.waterdogpe.utils.types.TextContainer;
+import dev.waterdog.waterdogpe.utils.types.TranslationContainer;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -93,6 +98,7 @@ public class ProxyServer {
     private final ConsoleCommandSender commandSender;
 
     private final SecurityManager securityManager;
+    private final ErrorReporting errorReporting;
 
     private IReconnectHandler reconnectHandler;
     private IJoinHandler joinHandler;
@@ -129,6 +135,7 @@ public class ProxyServer {
         this.configurationManager = new ConfigurationManager(this);
         this.configurationManager.loadProxyConfig();
         this.configurationManager.loadLanguage();
+        this.errorReporting = new ErrorReporting(this);
 
         if (!this.getNetworkSettings().enableIpv6()) {
             // Some devices and networks may not support IPv6
@@ -211,7 +218,7 @@ public class ProxyServer {
             }
         }
 
-        if(this.getConfiguration().isEnableAnonymousStatistics()){
+        if (this.getConfiguration().isEnableAnonymousStatistics()) {
             this.getLogger().info("Enabling anonymous statistics.");
             Metrics.startMetrics(this, this.getConfiguration());
         }
@@ -232,6 +239,8 @@ public class ProxyServer {
             InetSocketAddress additionalBind = new InetSocketAddress(bindAddress.getAddress(), port);
             this.bindChannels(additionalBind);
         }
+
+        logger.error("Testing", new Throwable("Some error that never exists"));
 
         ProxyStartEvent event = new ProxyStartEvent(this);
         this.eventManager.callEvent(event);
@@ -366,7 +375,7 @@ public class ProxyServer {
         }
 
         Command command = this.getCommandMap().getCommand(args[0]);
-        if (command == null)  {
+        if (command == null) {
             return false;
         }
 
@@ -600,5 +609,9 @@ public class ProxyServer {
 
     public EventLoopGroup getWorkerEventLoopGroup() {
         return this.workerEventLoopGroup;
+    }
+
+    public ErrorReporting getErrorReporting() {
+        return errorReporting;
     }
 }

--- a/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
@@ -240,8 +240,6 @@ public class ProxyServer {
             this.bindChannels(additionalBind);
         }
 
-        logger.error("Testing", new Throwable("Some error that never exists"));
-
         ProxyStartEvent event = new ProxyStartEvent(this);
         this.eventManager.callEvent(event);
 

--- a/src/main/java/dev/waterdog/waterdogpe/WaterdogPE.java
+++ b/src/main/java/dev/waterdog/waterdogpe/WaterdogPE.java
@@ -17,15 +17,19 @@ package dev.waterdog.waterdogpe;
 
 import dev.waterdog.waterdogpe.logger.MainLogger;
 import dev.waterdog.waterdogpe.network.protocol.ProtocolVersion;
+import dev.waterdog.waterdogpe.utils.reporting.Log4j2ErrorReporter;
 import io.netty.util.ResourceLeakDetector;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.layout.PatternLayout;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -41,6 +45,7 @@ public class WaterdogPE {
         Thread.currentThread().setName("WaterdogPE-main");
         System.out.println("Starting WaterdogPE....");
         System.setProperty("log4j.skipJansi", "false");
+        setupErrorLogger();
 
         MainLogger logger = MainLogger.getLogger();
         logger.info("§bStarting WaterDogPE proxy software!");
@@ -119,6 +124,19 @@ public class WaterdogPE {
 
     public static VersionInfo version() {
         return versionInfo;
+    }
+
+    private static void setupErrorLogger() {
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration config = ctx.getConfiguration();
+        Layout<? extends Serializable> layout = PatternLayout.createDefaultLayout(config);
+
+        Log4j2ErrorReporter reporter = new Log4j2ErrorReporter("ExceptionAppender", null, layout, false);
+
+        reporter.start();
+        config.addAppender(reporter);
+        ctx.getRootLogger().addAppender(reporter);
+        ctx.updateLoggers();
     }
 
     private static int getJavaVersion() {

--- a/src/main/java/dev/waterdog/waterdogpe/WaterdogPE.java
+++ b/src/main/java/dev/waterdog/waterdogpe/WaterdogPE.java
@@ -45,7 +45,6 @@ public class WaterdogPE {
         Thread.currentThread().setName("WaterdogPE-main");
         System.out.println("Starting WaterdogPE....");
         System.setProperty("log4j.skipJansi", "false");
-        setupErrorLogger();
 
         MainLogger logger = MainLogger.getLogger();
         logger.info("§bStarting WaterDogPE proxy software!");
@@ -124,19 +123,6 @@ public class WaterdogPE {
 
     public static VersionInfo version() {
         return versionInfo;
-    }
-
-    private static void setupErrorLogger() {
-        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        Configuration config = ctx.getConfiguration();
-        Layout<? extends Serializable> layout = PatternLayout.createDefaultLayout(config);
-
-        Log4j2ErrorReporter reporter = new Log4j2ErrorReporter("ExceptionAppender", null, layout, false);
-
-        reporter.start();
-        config.addAppender(reporter);
-        ctx.getRootLogger().addAppender(reporter);
-        ctx.updateLoggers();
     }
 
     private static int getJavaVersion() {

--- a/src/main/java/dev/waterdog/waterdogpe/utils/config/proxy/ProxyConfig.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/config/proxy/ProxyConfig.java
@@ -181,6 +181,10 @@ public class ProxyConfig extends YamlConfig {
     @Comment("Enable anonymous statistics that are sent to bstats. For more information, check out our bstats page at https://bstats.org/plugin/server-implementation/WaterdogPE/15678")
     private boolean enableAnonymousStatistics = true;
 
+    @Path("enable_error_reporting")
+    @Comment("Enables anonymous error reporting using bugsnag. This allows the WaterdogPE team to automatically collect issues occurring on WaterdogPE instances.")
+    private boolean enableAnonymousErrorReporting = true;
+
     public ProxyConfig(File file) {
         this.CONFIG_HEADER = new String[]{"Waterdog Main Configuration file", "Configure your desired network settings here."};
         this.CONFIG_FILE = file;

--- a/src/main/java/dev/waterdog/waterdogpe/utils/reporting/ErrorReporting.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/reporting/ErrorReporting.java
@@ -19,6 +19,13 @@ import com.bugsnag.Bugsnag;
 import com.bugsnag.Severity;
 import dev.waterdog.waterdogpe.ProxyServer;
 import dev.waterdog.waterdogpe.WaterdogPE;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+import java.io.Serializable;
 
 public class ErrorReporting {
 
@@ -44,8 +51,26 @@ public class ErrorReporting {
                 report.addToTab("os", "Version", System.getProperty("os.version"));
                 report.addToTab("os", "Architecture", System.getProperty("os.arch"));
             });
+
+            setupErrorLogger();
+
+            server.getLogger().info("Anonymous error reporting is enabled.");
         }
     }
+
+    private void setupErrorLogger() {
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration config = ctx.getConfiguration();
+        Layout<? extends Serializable> layout = PatternLayout.createDefaultLayout(config);
+
+        Log4j2ErrorReporter reporter = new Log4j2ErrorReporter("ExceptionAppender", null, layout, false);
+
+        reporter.start();
+        config.addAppender(reporter);
+        ctx.getRootLogger().addAppender(reporter);
+        ctx.updateLoggers();
+    }
+
 
     public boolean isEnabled() {
         return bugsnag != null;

--- a/src/main/java/dev/waterdog/waterdogpe/utils/reporting/ErrorReporting.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/reporting/ErrorReporting.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 WaterdogTEAM
+ * Licensed under the GNU General Public License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.waterdog.waterdogpe.utils.reporting;
+
+import com.bugsnag.Bugsnag;
+import com.bugsnag.Severity;
+import dev.waterdog.waterdogpe.ProxyServer;
+import dev.waterdog.waterdogpe.WaterdogPE;
+
+public class ErrorReporting {
+
+    private Bugsnag bugsnag = null;
+
+    public ErrorReporting(ProxyServer server) {
+        if (server.getConfiguration().isEnableAnonymousErrorReporting()) {
+            bugsnag = new Bugsnag("69403750fbff896b2e37022a56e3cde4");
+            bugsnag.setAppVersion(WaterdogPE.version().baseVersion());
+
+            bugsnag.addCallback(report -> {
+                report.addToTab("version", "commitId", WaterdogPE.version().commitId());
+                report.addToTab("version", "buildVersion", WaterdogPE.version().buildVersion());
+                report.addToTab("version", "baseVersion", WaterdogPE.version().baseVersion());
+                report.addToTab("version", "branchName", WaterdogPE.version().branchName());
+                report.addToTab("version", "latestProtocolVersion", WaterdogPE.version().latestProtocolVersion());
+
+                report.addToTab("java", "JVM version", System.getProperty("java.version"));
+                report.addToTab("java", "JVM runtime", System.getProperty("java.runtime.name"));
+                report.addToTab("java", "JVM runtime version", System.getProperty("java.runtime.version"));
+
+                report.addToTab("os", "Name", System.getProperty("os.name"));
+                report.addToTab("os", "Version", System.getProperty("os.version"));
+                report.addToTab("os", "Architecture", System.getProperty("os.arch"));
+            });
+        }
+    }
+
+    public boolean isEnabled() {
+        return bugsnag != null;
+    }
+
+    public void reportError(Throwable t, Severity severity) {
+        if(isEnabled()) {
+            bugsnag.notify(t, severity);
+        }
+    }
+}

--- a/src/main/java/dev/waterdog/waterdogpe/utils/reporting/Log4j2ErrorReporter.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/reporting/Log4j2ErrorReporter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 WaterdogTEAM
+ * Licensed under the GNU General Public License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.waterdog.waterdogpe.utils.reporting;
+
+import com.bugsnag.Severity;
+import dev.waterdog.waterdogpe.ProxyServer;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+
+import java.io.Serializable;
+
+public class Log4j2ErrorReporter extends AbstractAppender {
+
+
+    public Log4j2ErrorReporter(String name, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions) {
+        super(name, filter, layout, ignoreExceptions, Property.EMPTY_ARRAY);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        if (event.getThrown() == null) {
+            return;
+        }
+
+        ProxyServer.getInstance().getErrorReporting().reportError(event.getThrown(), event.getLevel().intLevel() > Level.WARN.intLevel() ? Severity.WARNING : Severity.ERROR);
+    }
+
+    public static void init() {
+        // no-op
+    }
+}


### PR DESCRIPTION
This PR introduces anonymous error reporting using https://bugsnag.com

This will give the WaterdogPE team to centrally monitor exceptions that occur and helps us to get a deeper insight into issues that are occurring.

The only data that is shared with WDPE is:

- Error Stack Traces
- JVM Information (JVM distro, version)
- Device Information (OS, OS Version, Architecture)
- WaterdogPE Information (Version, CommitID, latestProtocolVersion)

This is an opt-out feature that can be disabled simply by turning off `enable_error_reporting` in the proxies configuration file.

This PR is fully backwards compatible.