### PR TITLE
Fix broken usages of Protocol dependency

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/network/protocol/handler/downstream/InitialHandler.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/protocol/handler/downstream/InitialHandler.java
@@ -21,7 +21,7 @@ import dev.waterdog.waterdogpe.network.protocol.registry.FakeDefinitionRegistry;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
-import org.cloudburstmc.protocol.bedrock.data.defintions.ItemDefinition;
+import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
 import org.cloudburstmc.protocol.bedrock.packet.*;
 import dev.waterdog.waterdogpe.event.defaults.InitialServerConnectedEvent;
 import dev.waterdog.waterdogpe.network.serverinfo.ServerInfo;

--- a/src/main/java/dev/waterdog/waterdogpe/network/protocol/registry/FakeDefinitionRegistry.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/protocol/registry/FakeDefinitionRegistry.java
@@ -3,10 +3,10 @@ package dev.waterdog.waterdogpe.network.protocol.registry;
 import it.unimi.dsi.fastutil.ints.Int2ObjectFunction;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import org.cloudburstmc.protocol.bedrock.data.defintions.BlockDefinition;
-import org.cloudburstmc.protocol.bedrock.data.defintions.ItemDefinition;
-import org.cloudburstmc.protocol.bedrock.data.defintions.SimpleBlockDefinition;
-import org.cloudburstmc.protocol.bedrock.data.defintions.SimpleItemDefinition;
+import org.cloudburstmc.protocol.bedrock.data.definitions.BlockDefinition;
+import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
+import org.cloudburstmc.protocol.bedrock.data.definitions.SimpleBlockDefinition;
+import org.cloudburstmc.protocol.bedrock.data.definitions.SimpleItemDefinition;
 import org.cloudburstmc.protocol.common.Definition;
 import org.cloudburstmc.protocol.common.DefinitionRegistry;
 

--- a/src/main/java/dev/waterdog/waterdogpe/network/protocol/rewrite/BlockMap.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/protocol/rewrite/BlockMap.java
@@ -17,7 +17,7 @@ package dev.waterdog.waterdogpe.network.protocol.rewrite;
 
 import org.cloudburstmc.protocol.bedrock.data.LevelEventType;
 import org.cloudburstmc.protocol.bedrock.data.SoundEvent;
-import org.cloudburstmc.protocol.bedrock.data.defintions.BlockDefinition;
+import org.cloudburstmc.protocol.bedrock.data.definitions.BlockDefinition;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataMap;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.cloudburstmc.protocol.bedrock.packet.*;


### PR DESCRIPTION
It was renamed at https://github.com/CloudburstMC/Protocol/commit/bddf7b942a57aedd2885440626ed7b68c3131c94

Maven successfully builds after my changes, I suppose PR is ready to merge