### PR TITLE
fix incompatible byte -> CommandPermission conversion in Command

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/command/Command.java
+++ b/src/main/java/dev/waterdog/waterdogpe/command/Command.java
@@ -97,7 +97,7 @@ public abstract class Command {
         return new CommandData(this.name,
                 this.getDescription(),
                 Collections.emptySet(),
-                (byte) 0,
+                CommandPermission.ANY,
                 new CommandEnumData(this.name + "_aliases", aliases, false),
                 overloads);
     }


### PR DESCRIPTION
this fixes build error:
/build/waterdogpe/src/main/java/dev/waterdog/waterdogpe/command/Command.java:[100,17] incompatible types: byte cannot be converted to org.cloudburstmc.protocol.bedrock.data.command.CommandPermission