### PR TITLE
fix: fix NPE on early packet send for versions before 1.20.60

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/network/connection/peer/ProxiedBedrockPeer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/connection/peer/ProxiedBedrockPeer.java
@@ -118,8 +118,8 @@ public class ProxiedBedrockPeer extends BedrockPeer {
     private void sendPacket0(BedrockBatchWrapper wrapper) {
         if (!(wrapper.getAlgorithm() instanceof PacketCompressionAlgorithm)) {
             wrapper.setCompressed(null); // Do not allow using unsupported algorithms when sending to client
-        } else if (this.version.isBefore(ProtocolVersion.MINECRAFT_PE_1_20_60) &&
-                !Objects.equals(wrapper.getAlgorithm(), this.compressionStrategy.getDefaultCompression().getAlgorithm())) {
+        } else if (this.version.isBefore(ProtocolVersion.MINECRAFT_PE_1_20_60) && (this.compressionStrategy == null || 
+                !Objects.equals(wrapper.getAlgorithm(), this.compressionStrategy.getDefaultCompression().getAlgorithm()))) {
             wrapper.setCompressed(null); // Before 1.20.60 dynamic compression is not supported
         }
 


### PR DESCRIPTION
```
java.lang.NullPointerException: Cannot invoke "org.cloudburstmc.protocol.bedrock.netty.codec.compression.CompressionStrategy.getDefaultCompression()" because "this.compressionStrategy" is null
        at dev.waterdog.waterdogpe.network.connection.peer.ProxiedBedrockPeer.sendPacket0(ProxiedBedrockPeer.java:122) ~[waterdog.jar:?]
        at dev.waterdog.waterdogpe.network.connection.peer.ProxiedBedrockPeer.lambda$sendPacket$0(ProxiedBedrockPeer.java:114) ~[waterdog.jar:?]
        at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173) ~[waterdog.jar:?]
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166) ~[waterdog.jar:?]
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[waterdog.jar:?]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:413) ~[waterdog.jar:?]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[waterdog.jar:?]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[waterdog.jar:?]
```