### PR TITLE
Add UpdateEquipPacket support to protocol handling

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/network/protocol/ProtocolCodecs.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/protocol/ProtocolCodecs.java
@@ -113,6 +113,7 @@ public class ProtocolCodecs {
         HANDLED_PACKETS.add(ClientCheatAbilityPacket.class);
         HANDLED_PACKETS.add(ToastRequestPacket.class);
         HANDLED_PACKETS.add(MovementEffectPacket.class);
+        HANDLED_PACKETS.add(UpdateEquipPacket.class);
     }
 
     private static final List<ProtocolCodecUpdater> UPDATERS = new ObjectArrayList<>();

--- a/src/main/java/dev/waterdog/waterdogpe/network/protocol/rewrite/EntityMap.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/protocol/rewrite/EntityMap.java
@@ -357,6 +357,11 @@ public class EntityMap implements BedrockPacketHandler {
         return rewriteId(packet.getRuntimeEntityId(), packet::setRuntimeEntityId);
     }
 
+    @Override
+    public PacketSignal handle(UpdateEquipPacket packet) {
+        return rewriteId(packet.getUniqueEntityId(), packet::setUniqueEntityId);
+    }
+
     private PacketSignal rewriteMetadata(EntityDataMap metadata) {
         PacketSignal signal = PacketSignal.UNHANDLED;
         for (EntityDataType<Long> data : ENTITY_DATA_FIELDS) {


### PR DESCRIPTION
Hi, this fix allows the runtimeIds in this packet to be translated. It had simply been forgotten, and since not many people use it, it was never found before.