### PR TITLE
Don't eagerly resolve hostnames

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/utils/config/serializer/InetSocketAddressConverter.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/config/serializer/InetSocketAddressConverter.java
@@ -46,7 +46,7 @@ public class InetSocketAddressConverter implements Converter {
         String string = (String) object;
         String address = string.substring(0, string.lastIndexOf(":"));
         int port = Integer.parseInt(string.substring(string.lastIndexOf(":") + 1));
-        return new InetSocketAddress(address, port);
+        return InetSocketAddress.createUnresolved(address, port);
     }
 
     @Override


### PR DESCRIPTION
When running in a Kubernetes environment, a pod receive different IPs after each restart meaning that the hostname should not be resolved eagerly or the backend server will not be connectable. This change replaces the InetSocketAddress call with a InetSocketAddress#createUnresolved to lazily resolve the IP address from DNS.