### PR TITLE
Don't use getAddress() on InetSocketAddress

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
@@ -237,7 +237,7 @@ public class ProxyServer {
 
         this.bindChannels(bindAddress);
         for (Integer port : this.getConfiguration().getAdditionalPorts()) {
-            InetSocketAddress additionalBind = new InetSocketAddress(bindAddress.getAddress(), port);
+            InetSocketAddress additionalBind = new InetSocketAddress(bindAddress.getHostString(), port);
             this.bindChannels(additionalBind);
         }
 

--- a/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
@@ -655,7 +655,7 @@ public class ProxiedPlayer implements CommandSender {
     public void redirectServer(ServerInfo serverInfo) {
         Preconditions.checkNotNull(serverInfo, "Server info can not be null!");
         TransferPacket packet = new TransferPacket();
-        packet.setAddress(serverInfo.getPublicAddress().getAddress().getHostAddress());
+        packet.setAddress(serverInfo.getPublicAddress().getHostString());
         packet.setPort(serverInfo.getPublicAddress().getPort());
         this.sendPacket(packet);
     }

--- a/src/main/java/dev/waterdog/waterdogpe/utils/config/serializer/InetSocketAddressConverter.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/config/serializer/InetSocketAddressConverter.java
@@ -35,7 +35,7 @@ public class InetSocketAddressConverter implements Converter {
             return null;
         }
         InetSocketAddress address = (InetSocketAddress) object;
-        return address.getHostName() + ":" + address.getPort();
+        return address.getHostString() + ":" + address.getPort();
     }
 
     @Override

--- a/src/main/java/dev/waterdog/waterdogpe/utils/config/serializer/ServerEntryConverter.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/config/serializer/ServerEntryConverter.java
@@ -38,9 +38,9 @@ public class ServerEntryConverter implements Converter {
     public Object toConfig(Class<?> type, Object object, ParameterizedType parameterizedType) {
         Map<String, String> map = new HashMap<>();
         ServerEntry serverEntry = (ServerEntry) object;
-        map.put("address", serverEntry.getAddress().getAddress().getHostAddress() + ":" + serverEntry.getAddress().getPort());
+        map.put("address", serverEntry.getAddress().getHostString() + ":" + serverEntry.getAddress().getPort());
         if (serverEntry.getPublicAddress() != null && serverEntry.getPublicAddress() != serverEntry.getAddress()) {
-            map.put("public_address", serverEntry.getAddress().getAddress().getHostAddress() + ":" + serverEntry.getAddress().getPort());
+            map.put("public_address", serverEntry.getAddress().getHostString() + ":" + serverEntry.getAddress().getPort());
         }
         if (serverEntry.getServerType() != null) {
             map.put("server_type", serverEntry.getServerType().toString());


### PR DESCRIPTION
Fixes issues from the previous PR where unresolved InetSocketAddresses return `getAddress()` as null, so `getHostString()` should be used to support both.