### PR TITLE
Implement network interface system with registration and booting capabilities

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
@@ -305,13 +305,9 @@ public class ProxyServer {
     }
 
     /**
-     * Registers a network interface to the server.
-     * The server does not start the interface automatically — the caller is
-     * responsible for calling {@link NetworkInterface#start(InetSocketAddress)}
-     * after registration.
+     * Registers a network interface.
      * <p>
-     * The recommended place to register custom interfaces is within a
-     * {@link dev.waterdog.waterdogpe.event.defaults.ProxyStartEvent} handler.
+     * Interfaces registered after boot (e.g., in a ProxyStartEvent handler) must be started manually by calling {@link NetworkInterface#start(InetSocketAddress)}.
      */
     public void registerInterface(NetworkInterface interfaze) {
         if (shutdown) {

--- a/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
@@ -15,18 +15,25 @@
 
 package dev.waterdog.waterdogpe;
 
-import dev.waterdog.waterdogpe.command.*;
+import dev.waterdog.waterdogpe.command.Command;
+import dev.waterdog.waterdogpe.command.CommandMap;
+import dev.waterdog.waterdogpe.command.CommandSender;
+import dev.waterdog.waterdogpe.command.ConsoleCommandSender;
+import dev.waterdog.waterdogpe.command.DefaultCommandMap;
+import dev.waterdog.waterdogpe.command.SimpleCommandMap;
 import dev.waterdog.waterdogpe.command.utils.CommandUtils;
 import dev.waterdog.waterdogpe.console.TerminalConsole;
 import dev.waterdog.waterdogpe.event.EventManager;
 import dev.waterdog.waterdogpe.event.defaults.DispatchCommandEvent;
+import dev.waterdog.waterdogpe.event.defaults.NetworkRegisterEvent;
 import dev.waterdog.waterdogpe.event.defaults.ProxyStartEvent;
 import dev.waterdog.waterdogpe.logger.MainLogger;
 import dev.waterdog.waterdogpe.network.EventLoops;
+import dev.waterdog.waterdogpe.network.NetworkInterface;
 import dev.waterdog.waterdogpe.network.NetworkMetrics;
+import dev.waterdog.waterdogpe.network.NetworkStartupException;
+import dev.waterdog.waterdogpe.network.RakNetInterface;
 import dev.waterdog.waterdogpe.network.connection.codec.compression.CompressionType;
-import dev.waterdog.waterdogpe.network.connection.codec.initializer.OfflineServerChannelInitializer;
-import dev.waterdog.waterdogpe.network.connection.codec.initializer.ProxiedServerSessionInitializer;
 import dev.waterdog.waterdogpe.network.connection.codec.initializer.ProxiedSessionInitializer;
 import dev.waterdog.waterdogpe.network.connection.codec.query.QueryHandler;
 import dev.waterdog.waterdogpe.network.connection.handler.DefaultForcedHostHandler;
@@ -53,26 +60,25 @@ import dev.waterdog.waterdogpe.utils.config.proxy.ProxyConfig;
 import dev.waterdog.waterdogpe.utils.reporting.ErrorReporting;
 import dev.waterdog.waterdogpe.utils.types.TextContainer;
 import dev.waterdog.waterdogpe.utils.types.TranslationContainer;
-import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.Epoll;
-import io.netty.channel.unix.UnixChannelOption;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import lombok.Getter;
-import lombok.Setter;
-import net.cubespace.Yamler.Config.InvalidConfigurationException;
-import org.cloudburstmc.netty.channel.raknet.RakChannelFactory;
-import org.cloudburstmc.netty.channel.raknet.config.RakChannelOption;
-import org.cloudburstmc.netty.channel.raknet.config.RakServerCookieMode;
-import org.cloudburstmc.protocol.common.util.Preconditions;
-
 import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import lombok.Getter;
+import lombok.Setter;
+import net.cubespace.Yamler.Config.InvalidConfigurationException;
+import org.cloudburstmc.protocol.common.util.Preconditions;
 
 public class ProxyServer {
     @Getter
@@ -104,8 +110,7 @@ public class ProxyServer {
     @Getter
     private final ServerInfoMap serverInfoMap = new ServerInfoMap();
 
-    private final long serverId;
-    private final List<Channel> serverChannels = new ObjectArrayList<>();
+    private final List<NetworkInterface> interfaces = new ObjectArrayList<>();
 
     @Getter
     private QueryHandler queryHandler;
@@ -130,6 +135,7 @@ public class ProxyServer {
     private IForcedHostHandler forcedHostHandler;
     @Getter
     private NetworkMetrics networkMetrics;
+    @Getter
     private final EventLoopGroup bossEventLoopGroup;
     @Getter
     private final EventLoopGroup workerEventLoopGroup;
@@ -198,7 +204,7 @@ public class ProxyServer {
                 .daemon(true)
                 .build();
         ThreadFactoryBuilder bossFactory = ThreadFactoryBuilder.builder()
-                .format("RakNet Listener - #%d")
+                .format("Network Listener - #%d")
                 .priority(8)
                 .daemon(true)
                 .build();
@@ -216,7 +222,6 @@ public class ProxyServer {
         this.commandSender = new ConsoleCommandSender(this);
         this.commandMap = new DefaultCommandMap(this, SimpleCommandMap.DEFAULT_PREFIX);
         this.console = new TerminalConsole(this);
-        this.serverId = ThreadLocalRandom.current().nextLong();
 
         this.pluginManager.loadAllPlugins();
         this.configurationManager.loadServerInfos(this.serverInfoMap);
@@ -259,10 +264,22 @@ public class ProxyServer {
             this.queryHandler = new QueryHandler(this);
         }
 
-        this.bindChannels(bindAddress);
+        this.registerInterface(new RakNetInterface(this));
+
+        try {
+            this.bootNetworks(bindAddress);
+        } catch (NetworkStartupException e) {
+            this.logger.error("Failed to bind to primary address {}, shutting down", bindAddress, e);
+            this.shutdown();
+            return;
+        }
         for (Integer port : this.getConfiguration().getAdditionalPorts()) {
             InetSocketAddress additionalBind = new InetSocketAddress(bindAddress.getHostString(), port);
-            this.bindChannels(additionalBind);
+            try {
+                this.bootNetworks(additionalBind);
+            } catch (NetworkStartupException e) {
+                this.getLogger().error("Unable to bind to additional port {}, skipping", additionalBind, e);
+            }
         }
 
         ProxyStartEvent event = new ProxyStartEvent(this);
@@ -281,49 +298,48 @@ public class ProxyServer {
         this.tickFuture = this.tickExecutor.scheduleAtFixedRate(this::tickProcessor, 50, 50, TimeUnit.MILLISECONDS);
     }
 
-    private void bindChannels(InetSocketAddress address) {
-        boolean allowEpoll = Epoll.isAvailable();
-        int bindCount = allowEpoll && EventLoops.getChannelType() != EventLoops.ChannelType.NIO
-                ? Runtime.getRuntime().availableProcessors() : 1;
-
-        for (int i = 0; i < bindCount; i++) {
-            ServerBootstrap bootstrap = new ServerBootstrap()
-                    .channelFactory(RakChannelFactory.server(EventLoops.getChannelType().getDatagramChannel()))
-                    .group(this.bossEventLoopGroup, this.workerEventLoopGroup)
-                    // .option(CustomChannelOption.IP_DONT_FRAG, 2 /* IP_PMTUDISC_DO */)
-                    .option(RakChannelOption.RAK_GUID, this.serverId)
-                    .option(RakChannelOption.RAK_HANDLE_PING, true)
-                    .option(RakChannelOption.RAK_MAX_MTU, this.getNetworkSettings().getMaximumMtu())
-                    .option(RakChannelOption.RAK_SERVER_COOKIE_MODE, this.getNetworkSettings().enableCookies() ?
-                            RakServerCookieMode.ACTIVE : RakServerCookieMode.INVALID)
-                    .childOption(RakChannelOption.RAK_SESSION_TIMEOUT, 10000L)
-                    .childOption(RakChannelOption.RAK_ORDERING_CHANNELS, 1)
-                    .handler(new OfflineServerChannelInitializer(this))
-                    .childHandler(new ProxiedServerSessionInitializer(this));
-            if (allowEpoll) {
-                bootstrap.option(UnixChannelOption.SO_REUSEPORT, true);
-            }
-            ChannelFuture future = bootstrap
-                    .bind(address)
-                    .syncUninterruptibly();
-            if (future.isSuccess()) {
-                this.serverChannels.add(future.channel());
-            } else {
-                throw new IllegalStateException("Can not start server on " + address, future.cause());
-            }
+    private void bootNetworks(InetSocketAddress address) throws NetworkStartupException {
+        for (NetworkInterface interfaze : this.interfaces) {
+            interfaze.start(address);
         }
+    }
 
-        this.getLogger().info(new TranslationContainer("waterdog.query.start", address.toString()).getTranslated());
+    /**
+     * Registers a network interface to the server.
+     * The server does not start the interface automatically — the caller is
+     * responsible for calling {@link NetworkInterface#start(InetSocketAddress)}
+     * after registration.
+     * <p>
+     * The recommended place to register custom interfaces is within a
+     * {@link dev.waterdog.waterdogpe.event.defaults.ProxyStartEvent} handler.
+     */
+    public void registerInterface(NetworkInterface interfaze) {
+        if (shutdown) {
+            return;
+        }
+        NetworkRegisterEvent event = new NetworkRegisterEvent(interfaze);
+        this.eventManager.callEvent(event);
+        if (!event.isCancelled()) {
+            this.interfaces.add(interfaze);
+        }
+    }
+
+    /**
+     * Returns an unmodifiable list of registered network interfaces.
+     */
+    public List<NetworkInterface> getInterfaces() {
+        return Collections.unmodifiableList(this.interfaces);
     }
 
     private void tickProcessor() {
         if (this.shutdown && !this.tickFuture.isCancelled()) {
             this.tickFuture.cancel(false);
-            this.serverChannels.forEach(Channel::close);
+            this.interfaces.forEach(NetworkInterface::shutdown);
         }
 
         try {
             this.onTick(++this.currentTick);
+            this.interfaces.forEach(NetworkInterface::tick);
         } catch (Exception e) {
             this.logger.error("Error while ticking proxy!", e);
         }
@@ -367,16 +383,14 @@ public class ProxyServer {
         }
 
         try {
-            for (Channel channel : this.serverChannels) {
-                if (channel.isOpen()) {
-                    channel.close().syncUninterruptibly();
-                }
+            for (NetworkInterface interfaze : this.interfaces) {
+                interfaze.shutdown();
             }
         } catch (Exception e) {
             this.getLogger().error("Error while shutting down ProxyServer", e);
         }
 
-        if (!this.tickFuture.isCancelled()) {
+        if (this.tickFuture != null && !this.tickFuture.isCancelled()) {
             this.logger.info("Interrupting scheduler!");
             this.tickFuture.cancel(true);
         }

--- a/src/main/java/dev/waterdog/waterdogpe/event/defaults/NetworkRegisterEvent.java
+++ b/src/main/java/dev/waterdog/waterdogpe/event/defaults/NetworkRegisterEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 WaterdogTEAM
+ * Licensed under the GNU General Public License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.waterdog.waterdogpe.event.defaults;
+
+import dev.waterdog.waterdogpe.event.CancellableEvent;
+import dev.waterdog.waterdogpe.event.Event;
+import dev.waterdog.waterdogpe.network.NetworkInterface;
+import lombok.Getter;
+
+/**
+ * Called whenever a network interface is registered via {@link dev.waterdog.waterdogpe.ProxyServer#registerInterface}.
+ * This event can be cancelled to prevent the interface from being registered.
+ */
+@Getter
+public class NetworkRegisterEvent extends Event implements CancellableEvent {
+
+    private final NetworkInterface networkInterface;
+
+    public NetworkRegisterEvent(NetworkInterface networkInterface) {
+        this.networkInterface = networkInterface;
+    }
+}

--- a/src/main/java/dev/waterdog/waterdogpe/network/NetworkInterface.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/NetworkInterface.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 WaterdogTEAM
+ * Licensed under the GNU General Public License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.waterdog.waterdogpe.network;
+
+import java.net.InetSocketAddress;
+
+public interface NetworkInterface {
+
+    /**
+     * Starts the network interface, binding to the specified address and port.
+     * @throws NetworkStartupException If the network interface fails to start, such as if the port is already in use or if there are insufficient permissions.
+     */
+    void start(InetSocketAddress address) throws NetworkStartupException;
+
+    /**
+     * Shutdowns the network interface, closing all connections and releasing resources.
+     */
+    void shutdown();
+
+    /**
+     * Called every tick to allow the network interface to perform any necessary updates.
+     */
+    default void tick() {
+    }
+
+    /**
+     * Returns whether the network interface is currently running and able to accept connections.
+     */
+    boolean isRunning();
+}

--- a/src/main/java/dev/waterdog/waterdogpe/network/NetworkStartupException.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/NetworkStartupException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 WaterdogTEAM
+ * Licensed under the GNU General Public License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.waterdog.waterdogpe.network;
+
+public class NetworkStartupException extends Exception {
+
+    public NetworkStartupException(String message) {
+        super(message);
+    }
+
+    public NetworkStartupException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/dev/waterdog/waterdogpe/network/RakNetInterface.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/RakNetInterface.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 WaterdogTEAM
+ * Licensed under the GNU General Public License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.waterdog.waterdogpe.network;
+
+import dev.waterdog.waterdogpe.ProxyServer;
+import dev.waterdog.waterdogpe.network.connection.codec.initializer.OfflineServerChannelInitializer;
+import dev.waterdog.waterdogpe.network.connection.codec.initializer.ProxiedServerSessionInitializer;
+import dev.waterdog.waterdogpe.utils.types.TranslationContainer;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.unix.UnixChannelOption;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import org.cloudburstmc.netty.channel.raknet.RakChannelFactory;
+import org.cloudburstmc.netty.channel.raknet.config.RakChannelOption;
+import org.cloudburstmc.netty.channel.raknet.config.RakServerCookieMode;
+
+public class RakNetInterface implements NetworkInterface {
+
+    private final List<Channel> serverChannels = new ObjectArrayList<>();
+
+    private final ProxyServer server;
+
+    private final long serverId;
+
+    private boolean running = false;
+
+    public RakNetInterface(ProxyServer server) {
+        this.server = server;
+        this.serverId = ThreadLocalRandom.current().nextLong();
+    }
+
+    @Override
+    public void start(InetSocketAddress address) throws NetworkStartupException {
+        List<Channel> bound = new ObjectArrayList<>();
+        try {
+            boolean allowEpoll = Epoll.isAvailable();
+            int bindCount = allowEpoll && EventLoops.getChannelType() != EventLoops.ChannelType.NIO
+                    ? Runtime.getRuntime().availableProcessors() : 1;
+
+            for (int i = 0; i < bindCount; i++) {
+                ServerBootstrap bootstrap = new ServerBootstrap()
+                        .channelFactory(RakChannelFactory.server(EventLoops.getChannelType().getDatagramChannel()))
+                        .group(this.server.getBossEventLoopGroup(), this.server.getWorkerEventLoopGroup())
+                        // .option(CustomChannelOption.IP_DONT_FRAG, 2 /* IP_PMTUDISC_DO */)
+                        .option(RakChannelOption.RAK_GUID, this.serverId)
+                        .option(RakChannelOption.RAK_HANDLE_PING, true)
+                        .option(RakChannelOption.RAK_MAX_MTU, this.server.getNetworkSettings().getMaximumMtu())
+                        .option(RakChannelOption.RAK_SERVER_COOKIE_MODE, this.server.getNetworkSettings().enableCookies() ?
+                                RakServerCookieMode.ACTIVE : RakServerCookieMode.INVALID)
+                        .childOption(RakChannelOption.RAK_SESSION_TIMEOUT, 10000L)
+                        .childOption(RakChannelOption.RAK_ORDERING_CHANNELS, 1)
+                        .handler(new OfflineServerChannelInitializer(this.server))
+                        .childHandler(new ProxiedServerSessionInitializer(this.server));
+                if (allowEpoll) {
+                    bootstrap.option(UnixChannelOption.SO_REUSEPORT, true);
+                }
+                ChannelFuture future = bootstrap
+                        .bind(address)
+                        .syncUninterruptibly();
+                if (future.isSuccess()) {
+                    bound.add(future.channel());
+                } else {
+                    throw new IllegalStateException("Can not start server on " + address, future.cause());
+                }
+            }
+            this.serverChannels.addAll(bound);
+            this.running = true;
+            this.server.getLogger().info(new TranslationContainer("waterdog.query.start", address.toString()).getTranslated());
+        } catch (Exception e) {
+            for (Channel channel : bound) {
+                if (channel.isOpen()) {
+                    channel.close().syncUninterruptibly();
+                }
+            }
+            throw new NetworkStartupException("Failed to start RakNet", e);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        if (!running) {
+            return;
+        }
+        running = false;
+        for (Channel channel : this.serverChannels) {
+            if (channel.isOpen()) {
+                channel.close().syncUninterruptibly();
+            }
+        }
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+}


### PR DESCRIPTION
Extracts the hardcoded RakNet binding logic into a NetworkInterface interface, allowing multiple interfaces to be
  registered and bound to multiple addresses.

## Notable behavior changes
- Primary bind failure now triggers graceful shutdown instead of crashing with an unhandled exception.
- Additional port bind failures log and continue instead of failing the whole startup.
- Registering a network interface fires a NetworkRegisterEvent, allowing plugins to block registration.

This will be useful when [NetherNet](https://github.com/Mojang/bedrock-protocol-docs/blob/main/NetherNetOnboardingGuide.md) implementation comes out to the third party servers. (confirmed working on v1.26.30 preview with [my implementation](https://github.com/alvin0319/transport-nethernet))