### PR TITLE
Add support for HAProxy PROXY protocol in network settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <raklib.version>1.0.0.CR3-20260421.213623-35</raklib.version>
+        <raklib.version>1.1.0.CR1-20260515.194106-1</raklib.version>
         <protocol.version>3.0.0.Beta12-SNAPSHOT</protocol.version>
         <log4j2.version>2.25.4</log4j2.version>
         <jline.version>3.30.6</jline.version>
@@ -179,6 +179,13 @@
             <groupId>org.cloudburstmc.netty</groupId>
             <artifactId>netty-transport-raknet</artifactId>
             <version>${raklib.version}</version>
+        </dependency>
+        <dependency>
+            <!-- Pulled in transitively by netty-transport-raknet for PROXY protocol support;
+                 pinned here to keep it aligned with the rest of Netty. -->
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-haproxy</artifactId>
+            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
@@ -294,6 +294,7 @@ public class ProxyServer {
         this.logger.debug("Downstream <-> Proxy compression level " + this.getConfiguration().getDownstreamCompression());
         this.logger.debug("MTU Settings: max_user=" + this.getNetworkSettings().getMaximumMtu() + " max_server=" + this.getNetworkSettings().getMaximumDownstreamMtu());
         this.logger.debug("RakNet Cookies: enabled=" + this.getNetworkSettings().enableCookies());
+        this.logger.debug("PROXY protocol: enabled=" + this.getNetworkSettings().enableProxyProtocol());
 
         ProxiedSessionInitializer.ZLIB_RAW_STRATEGY.getDefaultCompression().setLevel(this.getConfiguration().getUpstreamCompression());
         ProxiedSessionInitializer.ZLIB_STRATEGY.getDefaultCompression().setLevel(this.getConfiguration().getUpstreamCompression());

--- a/src/main/java/dev/waterdog/waterdogpe/network/RakNetInterface.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/RakNetInterface.java
@@ -65,6 +65,7 @@ public class RakNetInterface implements NetworkInterface {
                         .option(RakChannelOption.RAK_MAX_MTU, this.server.getNetworkSettings().getMaximumMtu())
                         .option(RakChannelOption.RAK_SERVER_COOKIE_MODE, this.server.getNetworkSettings().enableCookies() ?
                                 RakServerCookieMode.ACTIVE : RakServerCookieMode.INVALID)
+                        .option(RakChannelOption.RAK_PROXY_PROTOCOL, this.server.getNetworkSettings().enableProxyProtocol())
                         .childOption(RakChannelOption.RAK_SESSION_TIMEOUT, 10000L)
                         .childOption(RakChannelOption.RAK_ORDERING_CHANNELS, 1)
                         .handler(new OfflineServerChannelInitializer(this.server))

--- a/src/main/java/dev/waterdog/waterdogpe/utils/config/proxy/NetworkSettings.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/config/proxy/NetworkSettings.java
@@ -59,6 +59,11 @@ public class NetworkSettings extends YamlConfig {
     @Comment("Enable RakNet cookies for additional security. Do NOT disable this unless you know what you are doing.")
     private boolean enableCookies = true;
 
+    @Path("enable_proxy_protocol")
+    @Accessors(fluent = true)
+    @Comment("Enable HAProxy PROXY protocol (v1/v2) so the proxy can read the real client address when running behind a load balancer (e.g. HAProxy/UDP forwarder)")
+    private boolean enableProxyProtocol = false;
+
     @Path("error_timeout")
     @Accessors(fluent = true)
     @Comment("How many seconds should a connection be blocked if an error is thrown. Set to 0 to disable.")


### PR DESCRIPTION
Bump netty-transport-raknet to 1.1.0.CR1, which ships a server handler that decodes HAProxy PROXY protocol (v1/v2) headers and rewrites each session's address to the real client address.

Expose this through a new enable_proxy_protocol network setting (default off) wired to the RAK_PROXY_PROTOCOL channel option, so the proxy can read the real client address when running behind a load balancer. Only enable it when the listening port is firewalled to trusted forwarders, otherwise clients can spoof their address.

netty-codec-haproxy is pinned to the project's netty version, as it is otherwise pulled in transitively at an older release.