### PR TITLE
Add CDN based resource pack delivery

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
@@ -217,7 +217,7 @@ public class ProxyServer {
         this.scheduler = new WaterdogScheduler(this);
         this.playerManager = new PlayerManager(this);
         this.eventManager = new EventManager(this);
-        this.packManager = new PackManager(this, this.packsPath);
+        this.packManager = new PackManager(this);
         this.securityManager = new SecurityManager(this);
         this.commandSender = new ConsoleCommandSender(this);
         this.commandMap = new DefaultCommandMap(this, SimpleCommandMap.DEFAULT_PREFIX);
@@ -263,7 +263,7 @@ public class ProxyServer {
         }
 
         if (this.getConfiguration().enableResourcePacks()) {
-            this.packManager.loadPacks();
+            this.packManager.loadPacks(this.packsPath);
         }
 
         InetSocketAddress bindAddress = this.getConfiguration().getBindAddress();

--- a/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/ProxyServer.java
@@ -217,7 +217,7 @@ public class ProxyServer {
         this.scheduler = new WaterdogScheduler(this);
         this.playerManager = new PlayerManager(this);
         this.eventManager = new EventManager(this);
-        this.packManager = new PackManager(this);
+        this.packManager = new PackManager(this, this.packsPath);
         this.securityManager = new SecurityManager(this);
         this.commandSender = new ConsoleCommandSender(this);
         this.commandMap = new DefaultCommandMap(this, SimpleCommandMap.DEFAULT_PREFIX);
@@ -232,8 +232,13 @@ public class ProxyServer {
     }
 
     public void reloadPackManager() {
-        this.packManager.clear();
-        this.packManager.loadPacks(this.packsPath);
+        try {
+            this.configurationManager.loadProxyConfig();
+        } catch (InvalidConfigurationException e) {
+            this.logger.error("Failed to reload proxy config, keeping the currently loaded packs!", e);
+            return;
+        }
+        this.packManager.reloadPacks();
     }
 
     private void boot() {
@@ -258,7 +263,7 @@ public class ProxyServer {
         }
 
         if (this.getConfiguration().enableResourcePacks()) {
-            this.packManager.loadPacks(this.packsPath);
+            this.packManager.loadPacks();
         }
 
         InetSocketAddress bindAddress = this.getConfiguration().getBindAddress();

--- a/src/main/java/dev/waterdog/waterdogpe/command/DefaultCommandMap.java
+++ b/src/main/java/dev/waterdog/waterdogpe/command/DefaultCommandMap.java
@@ -34,5 +34,6 @@ public class DefaultCommandMap extends SimpleCommandMap {
         this.registerCommand(new EndCommand());
         this.registerCommand(new StatusCommand());
         this.registerCommand(new PluginsCommand());
+        this.registerCommand(new ReloadPacksCommand());
     }
 }

--- a/src/main/java/dev/waterdog/waterdogpe/command/defaults/ReloadPacksCommand.java
+++ b/src/main/java/dev/waterdog/waterdogpe/command/defaults/ReloadPacksCommand.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 WaterdogTEAM
+ * Licensed under the GNU General Public License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.waterdog.waterdogpe.command.defaults;
+
+import dev.waterdog.waterdogpe.ProxyServer;
+import dev.waterdog.waterdogpe.command.Command;
+import dev.waterdog.waterdogpe.command.CommandSender;
+import dev.waterdog.waterdogpe.command.CommandSettings;
+
+public class ReloadPacksCommand extends Command {
+
+    public ReloadPacksCommand() {
+        super("wdreloadpacks", CommandSettings.builder()
+                .setDescription("waterdog.command.reloadpacks.description")
+                .setPermission("waterdog.command.reloadpacks.permission")
+                .setUsageMessage("waterdog.command.reloadpacks.usage").build());
+    }
+
+    @Override
+    public boolean onExecute(CommandSender sender, String alias, String[] args) {
+        ProxyServer proxy = ProxyServer.getInstance();
+        if (!proxy.getConfiguration().enableResourcePacks()) {
+            sender.sendMessage("§cResource packs are disabled in the config.");
+            return true;
+        }
+
+        sender.sendMessage("§eReloading resource packs, this may take a moment if packs are downloaded from a CDN..");
+        // Downloading may block, so keep it off the caller's thread; packs are swapped in atomically.
+        proxy.getScheduler().scheduleAsync(() -> {
+            try {
+                proxy.reloadPackManager();
+                sender.sendMessage("§aResource packs reloaded. New players will receive the updated packs.");
+            } catch (Exception e) {
+                sender.sendMessage("§cFailed to reload resource packs: " + e.getMessage());
+                proxy.getLogger().error("Failed to reload resource packs", e);
+            }
+        });
+        return true;
+    }
+}

--- a/src/main/java/dev/waterdog/waterdogpe/event/defaults/ResourcePacksRebuildEvent.java
+++ b/src/main/java/dev/waterdog/waterdogpe/event/defaults/ResourcePacksRebuildEvent.java
@@ -26,20 +26,10 @@ import org.cloudburstmc.protocol.bedrock.packet.ResourcePacksInfoPacket;
 public class ResourcePacksRebuildEvent extends Event {
 
     private final ResourcePacksInfoPacket packsInfoPacket;
-    /**
-     * Variant of the info packet whose entries carry CDN URLs. Sent to players on platforms
-     * which are not listed in the disable_cdn_for config option when CDN packs are configured.
-     */
-    private final ResourcePacksInfoPacket cdnPacksInfoPacket;
     private final ResourcePackStackPacket stackPacket;
 
     public ResourcePacksRebuildEvent(ResourcePacksInfoPacket packsInfoPacket, ResourcePackStackPacket stackPacket) {
-        this(packsInfoPacket, packsInfoPacket, stackPacket);
-    }
-
-    public ResourcePacksRebuildEvent(ResourcePacksInfoPacket packsInfoPacket, ResourcePacksInfoPacket cdnPacksInfoPacket, ResourcePackStackPacket stackPacket) {
         this.packsInfoPacket = packsInfoPacket;
-        this.cdnPacksInfoPacket = cdnPacksInfoPacket;
         this.stackPacket = stackPacket;
     }
 

--- a/src/main/java/dev/waterdog/waterdogpe/event/defaults/ResourcePacksRebuildEvent.java
+++ b/src/main/java/dev/waterdog/waterdogpe/event/defaults/ResourcePacksRebuildEvent.java
@@ -26,10 +26,20 @@ import org.cloudburstmc.protocol.bedrock.packet.ResourcePacksInfoPacket;
 public class ResourcePacksRebuildEvent extends Event {
 
     private final ResourcePacksInfoPacket packsInfoPacket;
+    /**
+     * Variant of the info packet whose entries carry CDN URLs. Sent to players on platforms
+     * which are not listed in the disable_cdn_for config option when CDN packs are configured.
+     */
+    private final ResourcePacksInfoPacket cdnPacksInfoPacket;
     private final ResourcePackStackPacket stackPacket;
 
     public ResourcePacksRebuildEvent(ResourcePacksInfoPacket packsInfoPacket, ResourcePackStackPacket stackPacket) {
+        this(packsInfoPacket, packsInfoPacket, stackPacket);
+    }
+
+    public ResourcePacksRebuildEvent(ResourcePacksInfoPacket packsInfoPacket, ResourcePacksInfoPacket cdnPacksInfoPacket, ResourcePackStackPacket stackPacket) {
         this.packsInfoPacket = packsInfoPacket;
+        this.cdnPacksInfoPacket = cdnPacksInfoPacket;
         this.stackPacket = stackPacket;
     }
 

--- a/src/main/java/dev/waterdog/waterdogpe/packs/PackManager.java
+++ b/src/main/java/dev/waterdog/waterdogpe/packs/PackManager.java
@@ -188,14 +188,11 @@ public class PackManager {
 
     private Set<Platform> parseDisabledCdnPlatforms() {
         Set<Platform> platforms = EnumSet.noneOf(Platform.class);
-        for (Map.Entry<String, Boolean> entry : this.proxy.getConfiguration().getDisableCdnPlatforms().entrySet()) {
-            if (!Boolean.TRUE.equals(entry.getValue())) {
-                continue;
-            }
+        for (String name : this.proxy.getConfiguration().getDisableCdnPlatforms()) {
             try {
-                platforms.add(Platform.valueOf(entry.getKey().trim().toUpperCase().replace(' ', '_')));
+                platforms.add(Platform.valueOf(name.trim().toUpperCase().replace(' ', '_')));
             } catch (IllegalArgumentException e) {
-                this.proxy.getLogger().warning("Unknown platform " + entry.getKey() + " in disable_cdn_for config option!");
+                this.proxy.getLogger().warning("Unknown platform " + name + " in disable_cdn_for config option!");
             }
         }
         return platforms;

--- a/src/main/java/dev/waterdog/waterdogpe/packs/PackManager.java
+++ b/src/main/java/dev/waterdog/waterdogpe/packs/PackManager.java
@@ -38,6 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.security.MessageDigest;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -55,27 +56,26 @@ public class PackManager {
     private static final ResourcePackStackPacket.Entry EDU_PACK = new ResourcePackStackPacket.Entry("0fba4063-dba1-4281-9b89-ff9390653530", "1.0.0", "");
 
     private final ProxyServer proxy;
-    // Swapped as a whole on (re)load so joining players always read a complete, consistent set.
+    // Rebuilt and swapped in as a whole on (re)load so joining players read a complete, consistent set.
     @Getter
-    private volatile Map<UUID, ResourcePack> packs = new HashMap<>();
+    private Map<UUID, ResourcePack> packs = new HashMap<>();
     @Getter
-    private volatile Map<String, ResourcePack> packsByIdVer = new HashMap<>();
+    private Map<String, ResourcePack> packsByIdVer = new HashMap<>();
 
     @Getter
-    private volatile ResourcePacksInfoPacket packsInfoPacket = new ResourcePacksInfoPacket();
+    private ResourcePacksInfoPacket packsInfoPacket = new ResourcePacksInfoPacket();
     @Getter
-    private volatile ResourcePackStackPacket stackPacket = new ResourcePackStackPacket();
+    private ResourcePackStackPacket stackPacket = new ResourcePackStackPacket();
 
-    private volatile ResourcePacksInfoPacket noCdnPacksInfoPacket;
+    private ResourcePacksInfoPacket noCdnPacksInfoPacket;
 
-    private volatile Set<Platform> disabledCdnPlatforms = EnumSet.noneOf(Platform.class);
+    private Set<Platform> disabledCdnPlatforms = EnumSet.noneOf(Platform.class);
 
-    // The packs directory, injected at construction; reloadPacks re-scans it.
-    private final Path packsPath;
+    // Directories loadPacks has been called with; reloadPacks re-scans all of them.
+    private final List<Path> packDirectories = new ArrayList<>();
 
-    public PackManager(ProxyServer proxy, Path packsPath) {
+    public PackManager(ProxyServer proxy) {
         this.proxy = proxy;
-        this.packsPath = Preconditions.checkNotNull(packsPath, "Packs directory can not be null!");
     }
 
     public void clear() {
@@ -89,24 +89,42 @@ public class PackManager {
     }
 
     /**
-     * Loads packs from their configured source and swaps them in for players who connect from now on;
-     * players already past the resource pack stage keep what they were sent. When pack_cdn_urls is
-     * empty the local packs folder is served, otherwise the CDN packs are. Safe to call at runtime,
-     * which is what {@link #reloadPacks()} does.
+     * Registers a packs directory and loads packs, swapping them in for players who connect from now on;
+     * players already past the resource pack stage keep what they were sent. May be called more than
+     * once to serve packs from several directories. When pack_cdn_urls is empty the registered folders
+     * are served, otherwise the CDN packs are.
      */
-    public void loadPacks() {
-        Preconditions.checkArgument(Files.isDirectory(this.packsPath), this.packsPath + " must be directory!");
+    public void loadPacks(Path packsDirectory) {
+        Preconditions.checkNotNull(packsDirectory, "Packs directory can not be null!");
+        Preconditions.checkArgument(Files.isDirectory(packsDirectory), packsDirectory + " must be directory!");
+        if (!this.packDirectories.contains(packsDirectory)) {
+            this.packDirectories.add(packsDirectory);
+        }
+        this.buildPacks();
+    }
+
+    /**
+     * Reloads packs from every directory {@link #loadPacks(Path)} was called with, picking up config
+     * changes and refreshing pack contents for players who connect from now on.
+     */
+    public void reloadPacks() {
+        this.buildPacks();
+    }
+
+    private void buildPacks() {
         this.proxy.getLogger().info("Loading resource packs!");
 
-        Path cacheDirectory = this.packsPath.resolveSibling("packs_cdn_cache");
+        Path cacheDirectory = this.cdnCacheDirectory();
         Set<Platform> disabled = this.parseDisabledCdnPlatforms();
         Map<UUID, ResourcePack> newPacks = new HashMap<>();
         Map<String, ResourcePack> newPacksByIdVer = new HashMap<>();
 
         List<String> cdnUrls = this.proxy.getConfiguration().getPackCdnUrls();
         if (cdnUrls.isEmpty()) {
-            this.loadLocalPacks(this.packsPath, newPacks, newPacksByIdVer);
-        } else {
+            for (Path directory : this.packDirectories) {
+                this.loadLocalPacks(directory, newPacks, newPacksByIdVer);
+            }
+        } else if (cacheDirectory != null) {
             this.loadCdnPacks(cacheDirectory, cdnUrls, newPacks, newPacksByIdVer);
         }
 
@@ -126,17 +144,15 @@ public class PackManager {
 
         // With the replaced packs closed, drop any cache files no longer backing a live pack (older
         // downloads, and everything if we just switched from CDN back to local packs).
-        this.cleanupCdnCache(cacheDirectory, newPacks.values());
+        if (cacheDirectory != null) {
+            this.cleanupCdnCache(cacheDirectory, newPacks.values());
+        }
 
         this.proxy.getLogger().info("Loaded " + this.packs.size() + " packs!");
     }
 
-    /**
-     * Reloads packs from the same directory {@link #loadPacks(Path)} was first called with, picking up
-     * any config changes and refreshing pack contents for players who connect from now on.
-     */
-    public void reloadPacks() {
-        this.loadPacks();
+    private Path cdnCacheDirectory() {
+        return this.packDirectories.isEmpty() ? null : this.packDirectories.get(0).resolveSibling("packs_cdn_cache");
     }
 
     private void loadLocalPacks(Path packsDirectory, Map<UUID, ResourcePack> packs, Map<String, ResourcePack> packsByIdVer) {

--- a/src/main/java/dev/waterdog/waterdogpe/packs/PackManager.java
+++ b/src/main/java/dev/waterdog/waterdogpe/packs/PackManager.java
@@ -21,6 +21,7 @@ import org.cloudburstmc.protocol.bedrock.data.ResourcePackType;
 import org.cloudburstmc.protocol.bedrock.packet.*;
 import dev.waterdog.waterdogpe.ProxyServer;
 import dev.waterdog.waterdogpe.event.defaults.ResourcePacksRebuildEvent;
+import dev.waterdog.waterdogpe.network.protocol.user.Platform;
 import dev.waterdog.waterdogpe.packs.types.ResourcePack;
 import dev.waterdog.waterdogpe.packs.types.ZipResourcePack;
 import dev.waterdog.waterdogpe.utils.FileUtils;
@@ -28,10 +29,19 @@ import org.cloudburstmc.protocol.common.util.Preconditions;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigInteger;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 public class PackManager {
@@ -50,7 +60,12 @@ public class PackManager {
     @Getter
     private final ResourcePacksInfoPacket packsInfoPacket = new ResourcePacksInfoPacket();
     @Getter
+    private final ResourcePacksInfoPacket cdnPacksInfoPacket = new ResourcePacksInfoPacket();
+    @Getter
     private final ResourcePackStackPacket stackPacket = new ResourcePackStackPacket();
+
+    private Set<Platform> disabledCdnPlatforms = EnumSet.noneOf(Platform.class);
+    private boolean hasCdnPacks;
 
     public PackManager(ProxyServer proxy) {
         this.proxy = proxy;
@@ -85,8 +100,105 @@ public class PackManager {
             this.proxy.getLogger().error("Can not load packs!", e);
         }
 
+        this.loadCdnPacks(packsDirectory.resolveSibling("packs_cdn_cache"));
+
         this.rebuildPackets();
         this.proxy.getLogger().info("Loaded " + this.packs.size() + " packs!");
+    }
+
+    private void loadCdnPacks(Path cacheDirectory) {
+        this.disabledCdnPlatforms = this.parseDisabledCdnPlatforms();
+
+        for (String url : this.proxy.getConfiguration().getPackCdnUrls()) {
+            try {
+                Path packPath = this.downloadCdnPack(url, cacheDirectory);
+                if (packPath == null) {
+                    continue;
+                }
+
+                ResourcePack pack = this.loadPack(packPath, ZipResourcePack.class);
+                if (pack == null) {
+                    this.proxy.getLogger().error("CDN resource pack from " + url + " has invalid or missing manifest.json!");
+                    continue;
+                }
+
+                if (this.packs.containsKey(pack.getPackId())) {
+                    this.proxy.getLogger().warning("CDN resource pack from " + url + " has the same UUID as an already loaded pack ("
+                            + pack.getPackId() + ")! Skipping the CDN pack. Remove the local copy from the packs folder to serve it from the CDN.");
+                    pack.close();
+                    continue;
+                }
+
+                pack.setCdnUrl(url);
+                this.packsByIdVer.put(pack.getPackId() + "_" + pack.getVersion(), pack);
+                this.packs.put(pack.getPackId(), pack);
+                this.proxy.getLogger().info("Loaded CDN resource pack " + pack.getPackName() + " (" + pack.getPackId() + ") from " + url);
+            } catch (Exception e) {
+                this.proxy.getLogger().error("Can not load CDN resource pack from " + url, e);
+            }
+        }
+    }
+
+    /**
+     * Downloads the pack so its manifest, size and hash are known and chunked
+     * transfer stays available as fallback. If the download fails but a copy from
+     * a previous start exists in the cache, that copy is used instead.
+     */
+    private Path downloadCdnPack(String url, Path cacheDirectory) throws IOException {
+        Files.createDirectories(cacheDirectory);
+        Path packPath = cacheDirectory.resolve(this.hashUrl(url) + ".zip");
+        Path downloadPath = cacheDirectory.resolve(this.hashUrl(url) + ".zip.part");
+
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .followRedirects(HttpClient.Redirect.NORMAL)
+                    .connectTimeout(Duration.ofSeconds(15))
+                    .build();
+            HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                    .timeout(Duration.ofMinutes(2))
+                    .build();
+
+            HttpResponse<Path> response = client.send(request, HttpResponse.BodyHandlers.ofFile(downloadPath,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE));
+            if (response.statusCode() != 200) {
+                throw new IOException("Server responded with status code " + response.statusCode());
+            }
+            Files.move(downloadPath, packPath, StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            Files.deleteIfExists(downloadPath);
+            if (Files.exists(packPath)) {
+                this.proxy.getLogger().warning("Failed to download CDN resource pack from " + url + ": " + e.getMessage()
+                        + "! Using the copy cached from a previous start. Note that clients will still download from the CDN, so the URL must serve the same pack once reachable again.");
+                return packPath;
+            }
+            this.proxy.getLogger().error("Failed to download CDN resource pack from " + url + " and no cached copy exists! Skipping this pack.", e);
+            return null;
+        }
+        return packPath;
+    }
+
+    private String hashUrl(String url) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(url.getBytes(StandardCharsets.UTF_8));
+            return new BigInteger(1, digest).toString(16);
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to hash pack url", e);
+        }
+    }
+
+    private Set<Platform> parseDisabledCdnPlatforms() {
+        Set<Platform> platforms = EnumSet.noneOf(Platform.class);
+        for (Map.Entry<String, Boolean> entry : this.proxy.getConfiguration().getDisableCdnPlatforms().entrySet()) {
+            if (!Boolean.TRUE.equals(entry.getValue())) {
+                continue;
+            }
+            try {
+                platforms.add(Platform.valueOf(entry.getKey().trim().toUpperCase().replace(' ', '_')));
+            } catch (IllegalArgumentException e) {
+                this.proxy.getLogger().warning("Unknown platform " + entry.getKey() + " in disable_cdn_for config option!");
+            }
+        }
+        return platforms;
     }
 
     private ResourcePack constructPack(Path packPath) {
@@ -169,25 +281,38 @@ public class PackManager {
         this.packsInfoPacket.setForcedToAccept(this.proxy.getConfiguration().isForceServerPacks());
         this.packsInfoPacket.setWorldTemplateId(UUID.randomUUID());
         this.packsInfoPacket.setWorldTemplateVersion("");
+        this.cdnPacksInfoPacket.setForcedToAccept(this.packsInfoPacket.isForcedToAccept());
+        this.cdnPacksInfoPacket.setWorldTemplateId(this.packsInfoPacket.getWorldTemplateId());
+        this.cdnPacksInfoPacket.setWorldTemplateVersion(this.packsInfoPacket.getWorldTemplateVersion());
         this.stackPacket.setForcedToAccept(this.proxy.getConfiguration().isOverwriteClientPacks());
 
         this.packsInfoPacket.getBehaviorPackInfos().clear();
         this.packsInfoPacket.getResourcePackInfos().clear();
+
+        this.cdnPacksInfoPacket.getBehaviorPackInfos().clear();
+        this.cdnPacksInfoPacket.getResourcePackInfos().clear();
 
         this.stackPacket.getBehaviorPacks().clear();
         this.stackPacket.getResourcePacks().clear();
 
         this.stackPacket.setGameVersion("");
 
+        this.hasCdnPacks = false;
         for (ResourcePack pack : this.packs.values()) {
-            ResourcePacksInfoPacket.Entry infoEntry = new ResourcePacksInfoPacket.Entry(pack.getPackId(), pack.getVersion().toString(),
-                    pack.getPackSize(), pack.getContentKey(), "", pack.getContentKey().isEmpty() ? "" : pack.getPackId().toString(), false, false, false, null);
+            ResourcePacksInfoPacket.Entry infoEntry = this.createInfoEntry(pack, null);
+            // Separate entry instance carrying the CDN URL, so mutating one packet never leaks into the other
+            ResourcePacksInfoPacket.Entry cdnInfoEntry = this.createInfoEntry(pack, pack.getCdnUrl());
             ResourcePackStackPacket.Entry stackEntry = new ResourcePackStackPacket.Entry(pack.getPackId().toString(), pack.getVersion().toString(), "");
+            if (pack.getCdnUrl() != null) {
+                this.hasCdnPacks = true;
+            }
             if (pack.getType().equals(ResourcePack.TYPE_RESOURCES)) {
                 this.packsInfoPacket.getResourcePackInfos().add(infoEntry);
+                this.cdnPacksInfoPacket.getResourcePackInfos().add(cdnInfoEntry);
                 this.stackPacket.getResourcePacks().add(stackEntry);
             } else if (pack.getType().equals(ResourcePack.TYPE_DATA)) {
                 this.packsInfoPacket.getBehaviorPackInfos().add(infoEntry);
+                this.cdnPacksInfoPacket.getBehaviorPackInfos().add(cdnInfoEntry);
                 this.stackPacket.getBehaviorPacks().add(stackEntry);
             }
         }
@@ -195,8 +320,25 @@ public class PackManager {
         if (this.proxy.getConfiguration().enableEducationFeatures()) {
             this.stackPacket.getBehaviorPacks().add(EDU_PACK);
         }
-        ResourcePacksRebuildEvent event = new ResourcePacksRebuildEvent(this.packsInfoPacket, this.stackPacket);
+        ResourcePacksRebuildEvent event = new ResourcePacksRebuildEvent(this.packsInfoPacket, this.cdnPacksInfoPacket, this.stackPacket);
         this.proxy.getEventManager().callEvent(event);
+    }
+
+    private ResourcePacksInfoPacket.Entry createInfoEntry(ResourcePack pack, String cdnUrl) {
+        return new ResourcePacksInfoPacket.Entry(pack.getPackId(), pack.getVersion().toString(),
+                pack.getPackSize(), pack.getContentKey(), "", pack.getContentKey().isEmpty() ? "" : pack.getPackId().toString(), false, false, false, cdnUrl);
+    }
+
+    /**
+     * Returns the ResourcePacksInfoPacket which should be sent to a player on the given platform.
+     * Platforms listed in the disable_cdn_for config option always receive the packet without
+     * CDN URLs, causing them to use the in-protocol chunked transfer.
+     */
+    public ResourcePacksInfoPacket getPacksInfoPacket(Platform platform) {
+        if (!this.hasCdnPacks || this.disabledCdnPlatforms.contains(platform)) {
+            return this.packsInfoPacket;
+        }
+        return this.cdnPacksInfoPacket;
     }
 
     public ResourcePackDataInfoPacket packInfoFromIdVer(String idVersion) {

--- a/src/main/java/dev/waterdog/waterdogpe/packs/PackManager.java
+++ b/src/main/java/dev/waterdog/waterdogpe/packs/PackManager.java
@@ -38,8 +38,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.security.MessageDigest;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -52,23 +55,27 @@ public class PackManager {
     private static final ResourcePackStackPacket.Entry EDU_PACK = new ResourcePackStackPacket.Entry("0fba4063-dba1-4281-9b89-ff9390653530", "1.0.0", "");
 
     private final ProxyServer proxy;
+    // Swapped as a whole on (re)load so joining players always read a complete, consistent set.
     @Getter
-    private final Map<UUID, ResourcePack> packs = new HashMap<>();
+    private volatile Map<UUID, ResourcePack> packs = new HashMap<>();
     @Getter
-    private final Map<String, ResourcePack> packsByIdVer = new HashMap<>();
+    private volatile Map<String, ResourcePack> packsByIdVer = new HashMap<>();
 
     @Getter
-    private final ResourcePacksInfoPacket packsInfoPacket = new ResourcePacksInfoPacket();
+    private volatile ResourcePacksInfoPacket packsInfoPacket = new ResourcePacksInfoPacket();
     @Getter
-    private final ResourcePacksInfoPacket cdnPacksInfoPacket = new ResourcePacksInfoPacket();
-    @Getter
-    private final ResourcePackStackPacket stackPacket = new ResourcePackStackPacket();
+    private volatile ResourcePackStackPacket stackPacket = new ResourcePackStackPacket();
 
-    private Set<Platform> disabledCdnPlatforms = EnumSet.noneOf(Platform.class);
-    private boolean hasCdnPacks;
+    private volatile ResourcePacksInfoPacket noCdnPacksInfoPacket;
 
-    public PackManager(ProxyServer proxy) {
+    private volatile Set<Platform> disabledCdnPlatforms = EnumSet.noneOf(Platform.class);
+
+    // The packs directory, injected at construction; reloadPacks re-scans it.
+    private final Path packsPath;
+
+    public PackManager(ProxyServer proxy, Path packsPath) {
         this.proxy = proxy;
+        this.packsPath = Preconditions.checkNotNull(packsPath, "Packs directory can not be null!");
     }
 
     public void clear() {
@@ -81,35 +88,73 @@ public class PackManager {
         this.packsByIdVer.clear();
     }
 
-    public void loadPacks(Path packsDirectory) {
-        Preconditions.checkNotNull(packsDirectory, "Packs directory can not be null!");
-        Preconditions.checkArgument(Files.isDirectory(packsDirectory), packsDirectory + " must be directory!");
+    /**
+     * Loads packs from their configured source and swaps them in for players who connect from now on;
+     * players already past the resource pack stage keep what they were sent. When pack_cdn_urls is
+     * empty the local packs folder is served, otherwise the CDN packs are. Safe to call at runtime,
+     * which is what {@link #reloadPacks()} does.
+     */
+    public void loadPacks() {
+        Preconditions.checkArgument(Files.isDirectory(this.packsPath), this.packsPath + " must be directory!");
         this.proxy.getLogger().info("Loading resource packs!");
 
-        try {
-            DirectoryStream<Path> stream = Files.newDirectoryStream(packsDirectory);
+        Path cacheDirectory = this.packsPath.resolveSibling("packs_cdn_cache");
+        Set<Platform> disabled = this.parseDisabledCdnPlatforms();
+        Map<UUID, ResourcePack> newPacks = new HashMap<>();
+        Map<String, ResourcePack> newPacksByIdVer = new HashMap<>();
+
+        List<String> cdnUrls = this.proxy.getConfiguration().getPackCdnUrls();
+        if (cdnUrls.isEmpty()) {
+            this.loadLocalPacks(this.packsPath, newPacks, newPacksByIdVer);
+        } else {
+            this.loadCdnPacks(cacheDirectory, cdnUrls, newPacks, newPacksByIdVer);
+        }
+
+        // Swap the freshly built set in first, then dispose the old one, so an in-flight chunk request
+        // is already reading the new packs before we close the packs it replaced.
+        Map<UUID, ResourcePack> oldPacks = this.packs;
+        this.disabledCdnPlatforms = disabled;
+        this.packs = newPacks;
+        this.packsByIdVer = newPacksByIdVer;
+        this.rebuildPackets();
+
+        for (ResourcePack pack : oldPacks.values()) {
+            try {
+                pack.close();
+            } catch (IOException ignored) {}
+        }
+
+        // With the replaced packs closed, drop any cache files no longer backing a live pack (older
+        // downloads, and everything if we just switched from CDN back to local packs).
+        this.cleanupCdnCache(cacheDirectory, newPacks.values());
+
+        this.proxy.getLogger().info("Loaded " + this.packs.size() + " packs!");
+    }
+
+    /**
+     * Reloads packs from the same directory {@link #loadPacks(Path)} was first called with, picking up
+     * any config changes and refreshing pack contents for players who connect from now on.
+     */
+    public void reloadPacks() {
+        this.loadPacks();
+    }
+
+    private void loadLocalPacks(Path packsDirectory, Map<UUID, ResourcePack> packs, Map<String, ResourcePack> packsByIdVer) {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(packsDirectory)) {
             for (Path path : stream) {
                 ResourcePack resourcePack = this.constructPack(path);
                 if (resourcePack != null) {
-                    String packIdVer = resourcePack.getPackId() + "_" + resourcePack.getPackManifest().getHeader().getVersion();
-                    this.packsByIdVer.put(packIdVer, resourcePack);
-                    this.packs.put(resourcePack.getPackId(), resourcePack);
+                    packsByIdVer.put(resourcePack.getPackId() + "_" + resourcePack.getPackManifest().getHeader().getVersion(), resourcePack);
+                    packs.put(resourcePack.getPackId(), resourcePack);
                 }
             }
         } catch (IOException e) {
             this.proxy.getLogger().error("Can not load packs!", e);
         }
-
-        this.loadCdnPacks(packsDirectory.resolveSibling("packs_cdn_cache"));
-
-        this.rebuildPackets();
-        this.proxy.getLogger().info("Loaded " + this.packs.size() + " packs!");
     }
 
-    private void loadCdnPacks(Path cacheDirectory) {
-        this.disabledCdnPlatforms = this.parseDisabledCdnPlatforms();
-
-        for (String url : this.proxy.getConfiguration().getPackCdnUrls()) {
+    private void loadCdnPacks(Path cacheDirectory, List<String> urls, Map<UUID, ResourcePack> packs, Map<String, ResourcePack> packsByIdVer) {
+        for (String url : urls) {
             try {
                 Path packPath = this.downloadCdnPack(url, cacheDirectory);
                 if (packPath == null) {
@@ -122,16 +167,16 @@ public class PackManager {
                     continue;
                 }
 
-                if (this.packs.containsKey(pack.getPackId())) {
-                    this.proxy.getLogger().warning("CDN resource pack from " + url + " has the same UUID as an already loaded pack ("
-                            + pack.getPackId() + ")! Skipping the CDN pack. Remove the local copy from the packs folder to serve it from the CDN.");
+                if (packs.containsKey(pack.getPackId())) {
+                    this.proxy.getLogger().warning("CDN resource pack from " + url + " has the same UUID as another CDN pack ("
+                            + pack.getPackId() + ")! Skipping the duplicate.");
                     pack.close();
                     continue;
                 }
 
                 pack.setCdnUrl(url);
-                this.packsByIdVer.put(pack.getPackId() + "_" + pack.getVersion(), pack);
-                this.packs.put(pack.getPackId(), pack);
+                packsByIdVer.put(pack.getPackId() + "_" + pack.getVersion(), pack);
+                packs.put(pack.getPackId(), pack);
                 this.proxy.getLogger().info("Loaded CDN resource pack " + pack.getPackName() + " (" + pack.getPackId() + ") from " + url);
             } catch (Exception e) {
                 this.proxy.getLogger().error("Can not load CDN resource pack from " + url, e);
@@ -139,15 +184,46 @@ public class PackManager {
         }
     }
 
+    private void cleanupCdnCache(Path cacheDirectory, Collection<ResourcePack> livePacks) {
+        if (!Files.isDirectory(cacheDirectory)) {
+            return;
+        }
+
+        Set<String> keep = new HashSet<>();
+        for (ResourcePack pack : livePacks) {
+            if (pack.getCdnUrl() != null) {
+                keep.add(pack.getPackPath().getFileName().toString());
+            }
+        }
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(cacheDirectory)) {
+            for (Path path : stream) {
+                if (keep.contains(path.getFileName().toString())) {
+                    continue;
+                }
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException ignored) {}
+            }
+        } catch (IOException e) {
+            this.proxy.getLogger().warning("Failed to clean up CDN pack cache: " + e.getMessage());
+        }
+    }
+
     /**
-     * Downloads the pack so its manifest, size and hash are known and chunked
-     * transfer stays available as fallback. If the download fails but a copy from
-     * a previous start exists in the cache, that copy is used instead.
+     * Downloads the pack so its manifest, size and hash are known and chunked transfer stays available
+     * as fallback. Each download lands in a uniquely named file so it never collides with a file the
+     * pack being replaced still holds open. If the download fails but a copy from an earlier load or a
+     * previous start exists in the cache, the newest such copy is used instead.
      */
     private Path downloadCdnPack(String url, Path cacheDirectory) throws IOException {
         Files.createDirectories(cacheDirectory);
-        Path packPath = cacheDirectory.resolve(this.hashUrl(url) + ".zip");
-        Path downloadPath = cacheDirectory.resolve(this.hashUrl(url) + ".zip.part");
+        String prefix = this.hashUrl(url);
+        // Unique per download (as Geyser does) so a fresh download never has to overwrite a file that a
+        // pack being replaced still holds open, which Windows would refuse.
+        String fileName = prefix + "." + System.currentTimeMillis();
+        Path packPath = cacheDirectory.resolve(fileName + ".zip");
+        Path downloadPath = cacheDirectory.resolve(fileName + ".zip.part");
 
         try {
             HttpClient client = HttpClient.newBuilder()
@@ -166,15 +242,35 @@ public class PackManager {
             Files.move(downloadPath, packPath, StandardCopyOption.REPLACE_EXISTING);
         } catch (Exception e) {
             Files.deleteIfExists(downloadPath);
-            if (Files.exists(packPath)) {
+            Path cached = this.findCachedPack(cacheDirectory, prefix);
+            if (cached != null) {
                 this.proxy.getLogger().warning("Failed to download CDN resource pack from " + url + ": " + e.getMessage()
-                        + "! Using the copy cached from a previous start. Note that clients will still download from the CDN, so the URL must serve the same pack once reachable again.");
-                return packPath;
+                        + "! Using a previously cached copy. Note that clients will still download from the CDN, so the URL must serve the same pack once reachable again.");
+                return cached;
             }
             this.proxy.getLogger().error("Failed to download CDN resource pack from " + url + " and no cached copy exists! Skipping this pack.", e);
             return null;
         }
         return packPath;
+    }
+
+    /**
+     * Finds the most recently cached copy of a pack (from any earlier download) for the given url hash,
+     * used as a fallback when a fresh download fails.
+     */
+    private Path findCachedPack(Path cacheDirectory, String prefix) {
+        Path newest = null;
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(cacheDirectory, prefix + ".*.zip")) {
+            long newestTime = Long.MIN_VALUE;
+            for (Path path : stream) {
+                long time = Files.getLastModifiedTime(path).toMillis();
+                if (time > newestTime) {
+                    newestTime = time;
+                    newest = path;
+                }
+            }
+        } catch (IOException ignored) {}
+        return newest;
     }
 
     private String hashUrl(String url) {
@@ -275,50 +371,43 @@ public class PackManager {
     }
 
     public void rebuildPackets() {
-        this.packsInfoPacket.setForcedToAccept(this.proxy.getConfiguration().isForceServerPacks());
-        this.packsInfoPacket.setWorldTemplateId(UUID.randomUUID());
-        this.packsInfoPacket.setWorldTemplateVersion("");
-        this.cdnPacksInfoPacket.setForcedToAccept(this.packsInfoPacket.isForcedToAccept());
-        this.cdnPacksInfoPacket.setWorldTemplateId(this.packsInfoPacket.getWorldTemplateId());
-        this.cdnPacksInfoPacket.setWorldTemplateVersion(this.packsInfoPacket.getWorldTemplateVersion());
-        this.stackPacket.setForcedToAccept(this.proxy.getConfiguration().isOverwriteClientPacks());
+        ResourcePacksInfoPacket infoPacket = new ResourcePacksInfoPacket();
+        infoPacket.setForcedToAccept(this.proxy.getConfiguration().isForceServerPacks());
+        infoPacket.setWorldTemplateId(UUID.randomUUID());
+        infoPacket.setWorldTemplateVersion("");
 
-        this.packsInfoPacket.getBehaviorPackInfos().clear();
-        this.packsInfoPacket.getResourcePackInfos().clear();
+        ResourcePackStackPacket stackPacket = new ResourcePackStackPacket();
+        stackPacket.setForcedToAccept(this.proxy.getConfiguration().isOverwriteClientPacks());
+        stackPacket.setGameVersion("");
 
-        this.cdnPacksInfoPacket.getBehaviorPackInfos().clear();
-        this.cdnPacksInfoPacket.getResourcePackInfos().clear();
-
-        this.stackPacket.getBehaviorPacks().clear();
-        this.stackPacket.getResourcePacks().clear();
-
-        this.stackPacket.setGameVersion("");
-
-        this.hasCdnPacks = false;
+        boolean hasCdnPacks = false;
         for (ResourcePack pack : this.packs.values()) {
-            ResourcePacksInfoPacket.Entry infoEntry = this.createInfoEntry(pack, null);
-            // Separate entry instance carrying the CDN URL, so mutating one packet never leaks into the other
-            ResourcePacksInfoPacket.Entry cdnInfoEntry = this.createInfoEntry(pack, pack.getCdnUrl());
+            // The CDN URL goes straight into the packet entry; disabled platforms get a stripped copy below.
+            ResourcePacksInfoPacket.Entry infoEntry = this.createInfoEntry(pack, pack.getCdnUrl());
             ResourcePackStackPacket.Entry stackEntry = new ResourcePackStackPacket.Entry(pack.getPackId().toString(), pack.getVersion().toString(), "");
             if (pack.getCdnUrl() != null) {
-                this.hasCdnPacks = true;
+                hasCdnPacks = true;
             }
             if (pack.getType().equals(ResourcePack.TYPE_RESOURCES)) {
-                this.packsInfoPacket.getResourcePackInfos().add(infoEntry);
-                this.cdnPacksInfoPacket.getResourcePackInfos().add(cdnInfoEntry);
-                this.stackPacket.getResourcePacks().add(stackEntry);
+                infoPacket.getResourcePackInfos().add(infoEntry);
+                stackPacket.getResourcePacks().add(stackEntry);
             } else if (pack.getType().equals(ResourcePack.TYPE_DATA)) {
-                this.packsInfoPacket.getBehaviorPackInfos().add(infoEntry);
-                this.cdnPacksInfoPacket.getBehaviorPackInfos().add(cdnInfoEntry);
-                this.stackPacket.getBehaviorPacks().add(stackEntry);
+                infoPacket.getBehaviorPackInfos().add(infoEntry);
+                stackPacket.getBehaviorPacks().add(stackEntry);
             }
         }
 
         if (this.proxy.getConfiguration().enableEducationFeatures()) {
-            this.stackPacket.getBehaviorPacks().add(EDU_PACK);
+            stackPacket.getBehaviorPacks().add(EDU_PACK);
         }
-        ResourcePacksRebuildEvent event = new ResourcePacksRebuildEvent(this.packsInfoPacket, this.cdnPacksInfoPacket, this.stackPacket);
+        ResourcePacksRebuildEvent event = new ResourcePacksRebuildEvent(infoPacket, stackPacket);
         this.proxy.getEventManager().callEvent(event);
+
+        this.noCdnPacksInfoPacket = (hasCdnPacks && !this.disabledCdnPlatforms.isEmpty())
+                ? this.buildNoCdnPacket(infoPacket) : null;
+        // Swap the freshly built packets in last so joining players never observe a half-built packet.
+        this.packsInfoPacket = infoPacket;
+        this.stackPacket = stackPacket;
     }
 
     private ResourcePacksInfoPacket.Entry createInfoEntry(ResourcePack pack, String cdnUrl) {
@@ -327,15 +416,39 @@ public class PackManager {
     }
 
     /**
+     * Builds a copy of packsInfoPacket with the CDN URL removed from every entry, so clients on
+     * platforms in disable_cdn_for fall back to the in-protocol chunked transfer.
+     */
+    private ResourcePacksInfoPacket buildNoCdnPacket(ResourcePacksInfoPacket source) {
+        ResourcePacksInfoPacket packet = new ResourcePacksInfoPacket();
+        packet.setForcedToAccept(source.isForcedToAccept());
+        packet.setWorldTemplateId(source.getWorldTemplateId());
+        packet.setWorldTemplateVersion(source.getWorldTemplateVersion());
+        for (ResourcePacksInfoPacket.Entry entry : source.getResourcePackInfos()) {
+            packet.getResourcePackInfos().add(this.stripCdnUrl(entry));
+        }
+        for (ResourcePacksInfoPacket.Entry entry : source.getBehaviorPackInfos()) {
+            packet.getBehaviorPackInfos().add(this.stripCdnUrl(entry));
+        }
+        return packet;
+    }
+
+    private ResourcePacksInfoPacket.Entry stripCdnUrl(ResourcePacksInfoPacket.Entry entry) {
+        return new ResourcePacksInfoPacket.Entry(entry.getPackId(), entry.getPackVersion(), entry.getPackSize(),
+                entry.getContentKey(), entry.getSubPackName(), entry.getContentId(), entry.isScripting(),
+                entry.isRaytracingCapable(), entry.isAddonPack(), null);
+    }
+
+    /**
      * Returns the ResourcePacksInfoPacket which should be sent to a player on the given platform.
-     * Platforms listed in the disable_cdn_for config option always receive the packet without
-     * CDN URLs, causing them to use the in-protocol chunked transfer.
+     * Platforms listed in the disable_cdn_for config option receive the packet without CDN URLs,
+     * causing them to use the in-protocol chunked transfer.
      */
     public ResourcePacksInfoPacket getPacksInfoPacket(Platform platform) {
-        if (!this.hasCdnPacks || this.disabledCdnPlatforms.contains(platform)) {
-            return this.packsInfoPacket;
+        if (this.noCdnPacksInfoPacket != null && this.disabledCdnPlatforms.contains(platform)) {
+            return this.noCdnPacksInfoPacket;
         }
-        return this.cdnPacksInfoPacket;
+        return this.packsInfoPacket;
     }
 
     public ResourcePackDataInfoPacket packInfoFromIdVer(String idVersion) {

--- a/src/main/java/dev/waterdog/waterdogpe/packs/types/ResourcePack.java
+++ b/src/main/java/dev/waterdog/waterdogpe/packs/types/ResourcePack.java
@@ -34,6 +34,13 @@ public abstract class ResourcePack {
     protected PackManifest packManifest;
     @Setter
     protected String contentKey;
+    /**
+     * When set, clients supporting it will download this pack directly from the URL
+     * instead of using the in-protocol chunked transfer. The URL must serve exactly
+     * the same bytes as this pack, since chunked transfer stays available as fallback.
+     */
+    @Setter
+    protected String cdnUrl;
 
     public ResourcePack(Path packPath) {
         this.packPath = packPath;

--- a/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
@@ -221,7 +221,7 @@ public class ProxiedPlayer implements CommandSender {
     }
 
     private void sendResourcePacks() {
-        ResourcePacksInfoPacket packet = this.proxy.getPackManager().getPacksInfoPacket();
+        ResourcePacksInfoPacket packet = this.proxy.getPackManager().getPacksInfoPacket(this.getDevicePlatform());
         PlayerResourcePackInfoSendEvent event = new PlayerResourcePackInfoSendEvent(this, packet);
         this.proxy.getEventManager().callEvent(event);
         if (event.isCancelled()) {

--- a/src/main/java/dev/waterdog/waterdogpe/utils/config/proxy/ProxyConfig.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/config/proxy/ProxyConfig.java
@@ -17,6 +17,7 @@ package dev.waterdog.waterdogpe.utils.config.proxy;
 
 import dev.waterdog.waterdogpe.ProxyServer;
 import dev.waterdog.waterdogpe.network.connection.codec.compression.CompressionType;
+import dev.waterdog.waterdogpe.network.protocol.user.Platform;
 import dev.waterdog.waterdogpe.utils.config.ServerList;
 import dev.waterdog.waterdogpe.utils.config.serializer.CompressionAlgorithmConverter;
 import dev.waterdog.waterdogpe.utils.config.serializer.InetSocketAddressConverter;
@@ -176,6 +177,25 @@ public class ProxyConfig extends YamlConfig {
     @Path("pack_cache_size")
     @Comment("You can set maximum pack size in MB to be cached.")
     private int packCacheSize = 16;
+
+    @Path("pack_cdn_urls")
+    @Comments({
+            "Resource packs which should be delivered to clients using a CDN URL instead of the in-protocol chunked transfer.",
+            "Each URL must point directly to the pack zip file and be publicly reachable over HTTPS.",
+            "Packs are downloaded once at startup to determine their manifest, size and hash, and remain available",
+            "via the chunked transfer as fallback for clients which can not download from the CDN."
+    })
+    private List<String> packCdnUrls = new ArrayList<>();
+
+    @Path("disable_cdn_for")
+    @Comments({
+            "Device platforms set to true never receive CDN URLs and instead get packs through the chunked transfer."
+    })
+    private Map<String, Boolean> disableCdnPlatforms = new LinkedHashMap<>() {{
+        for (Platform platform : Platform.values()) {
+            this.put(platform.name(), false);
+        }
+    }};
 
     @Path("default_idle_threads")
     @Comment("Creating threads may be in some situations expensive. Specify minimum count of idle threads per internal thread executors. Set to -1 to auto-detect by core count.")

--- a/src/main/java/dev/waterdog/waterdogpe/utils/config/proxy/ProxyConfig.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/config/proxy/ProxyConfig.java
@@ -17,7 +17,6 @@ package dev.waterdog.waterdogpe.utils.config.proxy;
 
 import dev.waterdog.waterdogpe.ProxyServer;
 import dev.waterdog.waterdogpe.network.connection.codec.compression.CompressionType;
-import dev.waterdog.waterdogpe.network.protocol.user.Platform;
 import dev.waterdog.waterdogpe.utils.config.ServerList;
 import dev.waterdog.waterdogpe.utils.config.serializer.CompressionAlgorithmConverter;
 import dev.waterdog.waterdogpe.utils.config.serializer.InetSocketAddressConverter;
@@ -189,13 +188,10 @@ public class ProxyConfig extends YamlConfig {
 
     @Path("disable_cdn_for")
     @Comments({
-            "Device platforms set to true never receive CDN URLs and instead get packs through the chunked transfer."
+            "Device platforms listed here never receive CDN URLs and instead get packs through the chunked transfer.",
+            "Example: [ANDROID, IOS]"
     })
-    private Map<String, Boolean> disableCdnPlatforms = new LinkedHashMap<>() {{
-        for (Platform platform : Platform.values()) {
-            this.put(platform.name(), false);
-        }
-    }};
+    private List<String> disableCdnPlatforms = new ArrayList<>();
 
     @Path("default_idle_threads")
     @Comment("Creating threads may be in some situations expensive. Specify minimum count of idle threads per internal thread executors. Set to -1 to auto-detect by core count.")

--- a/src/main/resources/lang.ini
+++ b/src/main/resources/lang.ini
@@ -41,3 +41,6 @@ waterdog.command.plugins.description=Show proxy server plugins list
 waterdog.command.plugins.usage=wdplugins
 waterdog.command.plugins.permission=waterdog.command.plugins
 waterdog.command.plugins.format=Plugins ({%0}): {%1}
+waterdog.command.reloadpacks.description=Reload resource packs from disk or the configured CDN URLs
+waterdog.command.reloadpacks.usage=wdreloadpacks
+waterdog.command.reloadpacks.permission=waterdog.command.reloadpacks


### PR DESCRIPTION
Resource packs can now be delivered to clients through a CDN URL instead of the in-protocol chunked transfer. Packs listed in the new pack_cdn_urls config option are downloaded once at startup so their manifest, size and hash are known, and are kept available through the chunked transfer as fallback for clients which can not download from the CDN. The new disable_cdn_for config option allows disabling CDN delivery per device platform, falling back to chunked transfer.