### PR TITLE
Fix/packet flood hardening

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/event/defaults/ServerTransferRequestEvent.java
+++ b/src/main/java/dev/waterdog/waterdogpe/event/defaults/ServerTransferRequestEvent.java
@@ -16,6 +16,7 @@
 package dev.waterdog.waterdogpe.event.defaults;
 
 import dev.waterdog.waterdogpe.event.CancellableEvent;
+import dev.waterdog.waterdogpe.event.CompletableEvent;
 import dev.waterdog.waterdogpe.network.serverinfo.ServerInfo;
 import dev.waterdog.waterdogpe.player.ProxiedPlayer;
 import lombok.Getter;
@@ -28,6 +29,7 @@ import lombok.Setter;
  */
 @Setter
 @Getter
+@CompletableEvent
 public class ServerTransferRequestEvent extends PlayerEvent implements CancellableEvent {
 
     private ServerInfo targetServer;

--- a/src/main/java/dev/waterdog/waterdogpe/network/connection/codec/server/ServerErrorHandler.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/connection/codec/server/ServerErrorHandler.java
@@ -33,7 +33,7 @@ public class ServerErrorHandler {
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-            log.error("Parent channel has thrown an exception", cause);
+            this.proxy.getSecurityManager().onParentChannelError(cause);
         }
     }
 

--- a/src/main/java/dev/waterdog/waterdogpe/network/connection/peer/ProxiedBedrockPeer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/connection/peer/ProxiedBedrockPeer.java
@@ -48,6 +48,7 @@ import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
 import org.cloudburstmc.protocol.bedrock.util.EncryptionUtils;
 
 import javax.crypto.SecretKey;
+import java.net.SocketAddress;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -57,6 +58,7 @@ public class ProxiedBedrockPeer extends BedrockPeer {
     @Getter
     private CompressionStrategy compressionStrategy;
     private ProtocolVersion version = ProtocolVersion.oldest();
+    private boolean errored;
 
     private final ProxyServer proxy;
 
@@ -240,8 +242,7 @@ public class ProxiedBedrockPeer extends BedrockPeer {
                 super.channelRead(ctx, ReferenceCountUtil.retain(msg));
             }
         } catch (Exception e) {
-            this.disconnect("Internal error");
-            this.proxy.getSecurityManager().onConnectionError(ctx.channel().remoteAddress(), e);
+            this.handleFailure(ctx.channel().remoteAddress(), e);
         } finally {
             ReferenceCountUtil.release(msg);
         }
@@ -249,7 +250,20 @@ public class ProxiedBedrockPeer extends BedrockPeer {
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        this.handleFailure(ctx.channel().remoteAddress(), cause);
+    }
+
+    /**
+     * Tears the peer down and reports the error at most once. Under a malformed-packet flood the pipeline
+     * can raise many exceptions on the same connection before it finishes closing; without this guard each
+     * one re-triggers disconnect and re-fails an already-completed promise, multiplying the log volume.
+     */
+    private void handleFailure(SocketAddress address, Throwable cause) {
+        if (this.errored) {
+            return;
+        }
+        this.errored = true;
         this.disconnect("Internal error");
-        this.proxy.getSecurityManager().onConnectionError(ctx.channel().remoteAddress(), cause);
+        this.proxy.getSecurityManager().onConnectionError(address, cause);
     }
 }

--- a/src/main/java/dev/waterdog/waterdogpe/network/protocol/user/HandshakeUtils.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/protocol/user/HandshakeUtils.java
@@ -138,7 +138,7 @@ public class HandshakeUtils {
         ECPublicKey identityPublicKey = (ECPublicKey) identityClaims.parsedIdentityPublicKey();
         String xuid = identityData.xuid;
         //UUID uuid = UUID.nameUUIDFromBytes(("pocket-auth-1-xuid:" + xuid).getBytes(StandardCharsets.UTF_8));
-        UUID uuid = identityData.identity;
+        UUID uuid = ProxyServer.getInstance().getConfiguration().getUuidFormat().resolve(identityData.identity, xuid);
         String minecraftId = identityData.minecraftId;
 
         SignedJWT clientDataJwt = SignedJWT.parse(packet.getClientJwt());
@@ -148,8 +148,7 @@ public class HandshakeUtils {
         }
         String displayName;
         if (ProxyServer.getInstance().getConfiguration().isReplaceUsernameSpaces()) {
-            displayName = identityData.displayName
-                    .replaceAll(" ", "_");
+            displayName = identityData.displayName.replace(" ", "_");
         } else {
             displayName = identityData.displayName;
         }
@@ -164,7 +163,7 @@ public class HandshakeUtils {
         // We are trying to replicate that behavior.
         return new HandshakeEntry(identityPublicKey, clientData, xuid, uuid, displayName, minecraftId, xboxAuth, protocol,
                 packet.getAuthPayload() instanceof CertificateChainPayload ||
-                    protocol.isBefore(ProtocolVersion.MINECRAFT_PE_1_26_20));
+                        protocol.isBefore(ProtocolVersion.MINECRAFT_PE_1_26_20));
     }
 
     public static JsonObject parseClientData(JWSObject clientJwt, String xuid, BedrockSession session) {

--- a/src/main/java/dev/waterdog/waterdogpe/network/protocol/user/UuidFormat.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/protocol/user/UuidFormat.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 WaterdogTEAM
+ * Licensed under the GNU General Public License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.waterdog.waterdogpe.network.protocol.user;
+
+import java.util.UUID;
+
+/**
+ * Determines how the unique id (UUID) of a connecting player is computed.
+ */
+public enum UuidFormat {
+
+    /**
+     * Uses the UUID parsed from the player's identity (login JWT chain). This is the default behaviour.
+     */
+    IDENTITY,
+
+    /**
+     * Derives the UUID from the player's XUID, identical to GeyserMC/Floodgate.
+     * The XUID is parsed as a long and stored in the lower 64 bits of the UUID, leaving the upper bits zeroed,
+     * which results in a zero-padded hex representation of the XUID.
+     */
+    FLOODGATE;
+
+    /**
+     * Resolves the UUID that should be assigned to the player based on this format.
+     * If the format can not be applied (e.g. FLOODGATE with a missing or non-numeric XUID),
+     * the identity UUID is returned as a fallback.
+     *
+     * @param identity the UUID parsed from the player's identity chain.
+     * @param xuid     the player's XUID.
+     * @return the UUID to use for the player.
+     */
+    public UUID resolve(UUID identity, String xuid) {
+        if (this != FLOODGATE || xuid == null || xuid.isEmpty()) {
+            return identity;
+        }
+        try {
+            return new UUID(0, Long.parseLong(xuid));
+        } catch (NumberFormatException e) {
+            return identity;
+        }
+    }
+}

--- a/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
@@ -83,6 +83,8 @@ public class ProxiedPlayer implements CommandSender {
      */
     private static final long LOGIN_EVENT_TIMEOUT_SECONDS = 60;
 
+    private static final long TRANSFER_EVENT_TIMEOUT_SECONDS = 30;
+
     @Getter
     private final RewriteData rewriteData = new RewriteData();
     @Getter
@@ -265,51 +267,68 @@ public class ProxiedPlayer implements CommandSender {
         Preconditions.checkArgument(this.loginCompleted.get(), "User not logged in");
 
         ServerTransferRequestEvent event = new ServerTransferRequestEvent(this, serverInfo);
-        ProxyServer.getInstance().getEventManager().callEvent(event);
-        if (event.isCancelled()) {
-            return;
-        }
+        this.proxy.getEventManager().callEvent(event)
+                .orTimeout(TRANSFER_EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .whenComplete((futureEvent, error) -> {
+            if (error != null) {
+                if (error instanceof TimeoutException) {
+                    this.getLogger().warning("[{}|{}] ServerTransferRequestEvent did not complete within {}s - aborting transfer to {}",
+                            this.getAddress(), this.getName(), TRANSFER_EVENT_TIMEOUT_SECONDS, serverInfo.getServerName());
+                } else {
+                    this.getLogger().throwing(error);
+                }
+                return;
+            }
 
-        ServerInfo targetServer = event.getTargetServer();
-        if (this.clientConnection != null && this.clientConnection.getServerInfo() == targetServer) {
-            this.sendMessage(new TranslationContainer("waterdog.downstream.connected", targetServer.getServerName()));
-            return;
-        }
+            if (event.isCancelled()) {
+                return;
+            }
 
-        if (this.pendingServers.contains(targetServer)) {
-            this.sendMessage(new TranslationContainer("waterdog.downstream.connecting", targetServer.getServerName()));
-            return;
-        }
+            if (!this.isConnected() || this.disconnectReason != null) {
+                return;
+            }
 
-        this.pendingServers.add(targetServer);
+            ServerInfo targetServer = event.getTargetServer();
+            if (this.clientConnection != null && this.clientConnection.getServerInfo() == targetServer) {
+                this.sendMessage(new TranslationContainer("waterdog.downstream.connected", targetServer.getServerName()));
+                return;
+            }
 
-        ClientConnection connectingServer = this.getPendingConnection();
-        if (connectingServer != null) {
-            if (connectingServer.getServerInfo() == targetServer) {
-                this.pendingServers.remove(targetServer);
+            if (this.pendingServers.contains(targetServer)) {
                 this.sendMessage(new TranslationContainer("waterdog.downstream.connecting", targetServer.getServerName()));
                 return;
-            } else {
-                connectingServer.disconnect();
-                this.getLogger().debug("Discarding pending connection for " + this.getName() + "! Tried to join " + targetServer.getServerName());
             }
-            this.setPendingConnection(null);
-        }
 
-        targetServer.createConnection(this).addListener(future -> {
-            ClientConnection connection = null;
-            try {
-                if (future.cause() == null) {
-                    this.connect0(targetServer, connection = (ClientConnection) future.get());
+            this.pendingServers.add(targetServer);
+
+            ClientConnection connectingServer = this.getPendingConnection();
+            if (connectingServer != null) {
+                if (connectingServer.getServerInfo() == targetServer) {
+                    this.pendingServers.remove(targetServer);
+                    this.sendMessage(new TranslationContainer("waterdog.downstream.connecting", targetServer.getServerName()));
+                    return;
                 } else {
-                    this.connectFailure(null, targetServer, future.cause());
+                    connectingServer.disconnect();
+                    this.getLogger().debug("Discarding pending connection for " + this.getName() + "! Tried to join " + targetServer.getServerName());
                 }
-            } catch (Throwable e) {
-                this.connectFailure(connection, targetServer, e);
                 this.setPendingConnection(null);
-            } finally {
-                this.pendingServers.remove(targetServer);
             }
+
+            targetServer.createConnection(this).addListener(future -> {
+                ClientConnection connection = null;
+                try {
+                    if (future.cause() == null) {
+                        this.connect0(targetServer, connection = (ClientConnection) future.get());
+                    } else {
+                        this.connectFailure(null, targetServer, future.cause());
+                    }
+                } catch (Throwable e) {
+                    this.connectFailure(connection, targetServer, e);
+                    this.setPendingConnection(null);
+                } finally {
+                    this.pendingServers.remove(targetServer);
+                }
+            });
         });
     }
 

--- a/src/main/java/dev/waterdog/waterdogpe/security/SecurityManager.java
+++ b/src/main/java/dev/waterdog/waterdogpe/security/SecurityManager.java
@@ -18,6 +18,7 @@ package dev.waterdog.waterdogpe.security;
 import dev.waterdog.waterdogpe.ProxyServer;
 import dev.waterdog.waterdogpe.network.protocol.user.HandshakeEntry;
 import dev.waterdog.waterdogpe.utils.config.proxy.NetworkSettings;
+import io.netty.handler.codec.DecoderException;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
@@ -29,9 +30,15 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 @Log4j2
 public class SecurityManager {
+    // Malformed-packet flood visibility: one summary line at most this often, and only once the count in
+    // a window crosses this threshold, so incidental junk from a normal client does not raise a false alarm.
+    private static final long FLOOD_REPORT_INTERVAL_MS = 5000;
+    private static final long FLOOD_REPORT_THRESHOLD = 50;
+
     private final ProxyServer proxy;
     @Getter
     private final ConnectionThrottle connectionThrottle;
@@ -39,6 +46,8 @@ public class SecurityManager {
     private final ConnectionThrottle loginThrottle;
 
     private final Map<InetAddress, Long> blockedConnections = new ConcurrentHashMap<>();
+    private final AtomicLong malformedSinceReport = new AtomicLong();
+    private final AtomicLong lastFloodReport = new AtomicLong();
 
     @Getter
     @Setter
@@ -66,20 +75,26 @@ public class SecurityManager {
             Map.Entry<InetAddress, Long> entry = iterator.next();
             if (entry.getValue() != 0 && currTime > entry.getValue()) {
                 iterator.remove();
-                this.proxy.getLogger().info("Unblocked address {}", entry.getKey());
+                log.debug("Unblocked address {}", entry.getKey());
             }
         }
     }
 
     public void blockAddress(InetAddress address, long time, TimeUnit unit) {
+        // Bound the table so a flood of many (possibly spoofed) source addresses can not exhaust the heap.
+        // Once full we stop tracking new offenders until entries expire; throttling and edge mitigation cover the rest.
+        int max = this.proxy.getNetworkSettings().maxBlockedAddresses();
+        if (max > 0 && this.blockedConnections.size() >= max && !this.blockedConnections.containsKey(address)) {
+            return;
+        }
         long millis = unit.toMillis(time);
         this.blockedConnections.put(address, System.currentTimeMillis() + millis);
-        this.proxy.getLogger().info("Connection from {} is blocked for {}ms", address, millis);
+        log.debug("Connection from {} is blocked for {}ms", address, millis);
     }
 
     public void unblockAddress(InetAddress address) {
         if (this.blockedConnections.remove(address) != null) {
-            this.proxy.getLogger().info("Unblocked address {}", address);
+            log.debug("Unblocked address {}", address);
         }
     }
 
@@ -127,7 +142,16 @@ public class SecurityManager {
 
     public void onConnectionError(SocketAddress address, Throwable cause) {
         if (cause != null) {
-            log.error("{} Exception caught in bedrock connection", address, cause);
+            // Malformed/oversized packets from the network are untrusted input and expected under a flood.
+            // Logging a full stack trace for each one is the amplification vector that turns a cheap packet
+            // flood into an outage. Keep the per-packet detail at debug and surface a rate-limited summary
+            // instead, so a flood stays visible without the volume; reserve error+stack for real faults.
+            if (isNetworkInputError(cause)) {
+                log.debug("{} sent a packet that could not be decoded: {}", address, cause.toString());
+                this.tallyMalformed();
+            } else {
+                log.error("{} Exception caught in bedrock connection", address, cause);
+            }
         }
 
         int timeout = this.proxy.getNetworkSettings().errorTimeout();
@@ -136,7 +160,52 @@ public class SecurityManager {
         }
 
         if (address instanceof InetSocketAddress inet) {
-            this.proxy.getSecurityManager().blockAddress(inet.getAddress(), timeout, TimeUnit.SECONDS);
+            this.blockAddress(inet.getAddress(), timeout, TimeUnit.SECONDS);
         }
+    }
+
+    /**
+     * Handles an exception on the parent (bind) channel, which has no per-connection address to block.
+     * Malformed inbound packets are folded into the flood summary; genuine faults are logged in full.
+     */
+    public void onParentChannelError(Throwable cause) {
+        if (isNetworkInputError(cause)) {
+            log.debug("Parent channel dropped a packet that could not be decoded: {}", cause.toString());
+            this.tallyMalformed();
+        } else {
+            log.error("Parent channel has thrown an exception", cause);
+        }
+    }
+
+    /**
+     * Records a dropped malformed packet and, at most once per {@link #FLOOD_REPORT_INTERVAL_MS} and only
+     * once the count in a window crosses {@link #FLOOD_REPORT_THRESHOLD}, logs a single visible summary so
+     * an ongoing flood is obvious at the default log level without logging every packet.
+     */
+    private void tallyMalformed() {
+        this.malformedSinceReport.incrementAndGet();
+        long now = System.currentTimeMillis();
+        long last = this.lastFloodReport.get();
+        if (now - last >= FLOOD_REPORT_INTERVAL_MS && this.lastFloodReport.compareAndSet(last, now)) {
+            long count = this.malformedSinceReport.getAndSet(0);
+            if (count >= FLOOD_REPORT_THRESHOLD) {
+                log.warn("Dropping malformed packets from clients ({} in the last ~{}s) — possible packet flood; enable DEBUG for per-packet detail",
+                        count, FLOOD_REPORT_INTERVAL_MS / 1000);
+            }
+        }
+    }
+
+    /**
+     * Whether the throwable originates from decoding untrusted network input (a malformed or truncated
+     * packet), as opposed to a genuine internal error. Such errors are expected and must not be logged
+     * per-packet with a stack trace.
+     */
+    private static boolean isNetworkInputError(Throwable cause) {
+        for (Throwable t = cause; t != null; t = (t.getCause() == t ? null : t.getCause())) {
+            if (t instanceof DecoderException || t instanceof IndexOutOfBoundsException) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/dev/waterdog/waterdogpe/utils/config/proxy/NetworkSettings.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/config/proxy/NetworkSettings.java
@@ -18,6 +18,7 @@ package dev.waterdog.waterdogpe.utils.config.proxy;
 import lombok.Getter;
 import lombok.experimental.Accessors;
 import net.cubespace.Yamler.Config.Comment;
+import net.cubespace.Yamler.Config.Comments;
 import net.cubespace.Yamler.Config.Path;
 import net.cubespace.Yamler.Config.YamlConfig;
 import org.cloudburstmc.netty.channel.raknet.RakConstants;
@@ -68,4 +69,12 @@ public class NetworkSettings extends YamlConfig {
     @Accessors(fluent = true)
     @Comment("How many seconds should a connection be blocked if an error is thrown. Set to 0 to disable.")
     private int errorTimeout = 15;
+
+    @Path("max_blocked_addresses")
+    @Accessors(fluent = true)
+    @Comments({
+            "Maximum number of addresses kept in the temporary error-block list. Bounds memory use during a flood",
+            "of many (possibly spoofed) source addresses. Once full, new offenders are not tracked until entries expire."
+    })
+    private int maxBlockedAddresses = 65536;
 }

--- a/src/main/java/dev/waterdog/waterdogpe/utils/config/proxy/ProxyConfig.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/config/proxy/ProxyConfig.java
@@ -17,11 +17,13 @@ package dev.waterdog.waterdogpe.utils.config.proxy;
 
 import dev.waterdog.waterdogpe.ProxyServer;
 import dev.waterdog.waterdogpe.network.connection.codec.compression.CompressionType;
+import dev.waterdog.waterdogpe.network.protocol.user.UuidFormat;
 import dev.waterdog.waterdogpe.utils.config.ServerList;
 import dev.waterdog.waterdogpe.utils.config.serializer.CompressionAlgorithmConverter;
 import dev.waterdog.waterdogpe.utils.config.serializer.InetSocketAddressConverter;
 import dev.waterdog.waterdogpe.utils.config.serializer.ServerEntryConverter;
 import dev.waterdog.waterdogpe.utils.config.serializer.ServerListConverter;
+import dev.waterdog.waterdogpe.utils.config.serializer.UuidFormatConverter;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import lombok.Getter;
 import lombok.Setter;
@@ -125,6 +127,14 @@ public class ProxyConfig extends YamlConfig {
     @Comment("Replaces username spaces with underscores if enabled")
     private boolean replaceUsernameSpaces = false;
 
+    @Path("player_uuid_format")
+    @Comments({
+            "Determines how the proxy assigns the unique id (UUID) of connecting players.",
+            "IDENTITY: Uses the UUID parsed from the player's login chain (default).",
+            "FLOODGATE: Derives the UUID from the player's XUID (zero-padded hex of the XUID), identical to GeyserMC/Floodgate."
+    })
+    private UuidFormat uuidFormat = UuidFormat.IDENTITY;
+
     @Path("enable_query")
     @Accessors(fluent = true)
     @Comment("Whether server query should be enabled")
@@ -197,6 +207,7 @@ public class ProxyConfig extends YamlConfig {
             this.addConverter(ServerEntryConverter.class);
             this.addConverter(ServerListConverter.class);
             this.addConverter(CompressionAlgorithmConverter.class);
+            this.addConverter(UuidFormatConverter.class);
         } catch (InvalidConverterException e) {
             ProxyServer.getInstance().getLogger().error("Error while initiating config converters", e);
         }

--- a/src/main/java/dev/waterdog/waterdogpe/utils/config/serializer/UuidFormatConverter.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/config/serializer/UuidFormatConverter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 WaterdogTEAM
+ * Licensed under the GNU General Public License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.waterdog.waterdogpe.utils.config.serializer;
+
+import dev.waterdog.waterdogpe.network.protocol.user.UuidFormat;
+import net.cubespace.Yamler.Config.Converter.Converter;
+import net.cubespace.Yamler.Config.InternalConverter;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.Locale;
+
+public class UuidFormatConverter implements Converter {
+
+    public UuidFormatConverter(InternalConverter internalConverter) {
+    }
+
+    @Override
+    public Object toConfig(Class<?> type, Object object, ParameterizedType parameterizedType) {
+        if (object instanceof UuidFormat format) {
+            return format.name();
+        } else {
+            throw new IllegalArgumentException("Can not serialize " + object.getClass().getSimpleName() + " as UuidFormat");
+        }
+    }
+
+    @Override
+    public Object fromConfig(Class<?> type, Object object, ParameterizedType parameterizedType) {
+        if (object == null) {
+            return UuidFormat.IDENTITY;
+        }
+        try {
+            return UuidFormat.valueOf(object.toString().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return UuidFormat.IDENTITY;
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> type) {
+        return UuidFormat.class.isAssignableFrom(type);
+    }
+}


### PR DESCRIPTION
Malformed-packet flood causes log amplification → heap OOM (WaterdogPE)

Problem: A flood of tiny (~7-byte) malformed RakNet datagrams took a proxy down. The packets are correctly rejected by the cloudburst netty-raknet decoders (RakAcknowledgeHandler, EncapsulatedPacket.decode) with IndexOutOfBoundsException/DecoderException — the decoders aren't the issue. Waterdog's reaction is: every undecodable packet was logged with a full stack trace, and the per-connection exceptionCaught re-failed already-completed promises, logging a second exception (IllegalArgumentException: promise already done) each time. ~82k crafted packets produced 6.3M log lines / 676 MB, and the error-block map grew unbounded. The result was GC/IO saturation and OutOfMemoryError. It's a low-bandwidth application-layer DoS, not volumetric.

Root causes (all in the error/logging/blocking path):
1. SecurityManager.onConnectionError logged every connection error at ERROR with a stack trace.
2. ServerErrorHandler.Parent.exceptionCaught did the same on the shared server channel.
3. SecurityManager.blockedConnections was an unbounded map — many/spoofed sources exhaust the heap (the defense was itself a DoS vector).
4. ProxiedBedrockPeer.exceptionCaught tore down the connection and re-failed an already-done promise on every exception, incl. benign per-packet decode errors.

Fixes (fix/packet-flood-hardening, compiles on master):
1. Classify decoder/IndexOutOfBounds exceptions as untrusted input: per-packet detail at DEBUG, plus a rate-limited WARN summary (“Dropping malformed packets (N in the last ~5s) — possible packet flood”) so floods stay visible without the volume. Genuine errors still log ERROR+stack.
2. Bound the block map via new network_settings.max_blocked_addresses (default 65536); routine block/unblock logs moved to DEBUG.
3. Run disconnect + error-report once per peer to stop the “promise already done” storm.
4. Route the parent-channel handler through the same classifier so parent-channel floods are bounded and visible too.

Note: true volumetric protection still belongs upstream (UDP-capable LB / DDoS scrubbing); these changes make the proxy fail gracefully instead of amplifying a cheap flood into an outage.