### PR TITLE
Keep player on current server when a transfer fails

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
@@ -404,7 +404,10 @@ public class ProxiedPlayer implements CommandSender {
 
         this.getLogger().error("[{}|{}] Unable to connect to downstream {}", this.getAddress(), this.getName(), targetServer.getServerName(), error);
         String exceptionMessage = Objects.requireNonNullElse(error.getLocalizedMessage(), error.getClass().getSimpleName());
-        if (this.sendToFallback(targetServer, ReconnectReason.EXCEPTION, exceptionMessage)) {
+
+        if (this.clientConnection != null && this.clientConnection.isConnected()) {
+            this.sendMessage(new TranslationContainer("waterdog.downstream.transfer.failed", targetServer.getServerName(), exceptionMessage));
+        } else if (this.sendToFallback(targetServer, ReconnectReason.EXCEPTION, exceptionMessage)) {
             this.sendMessage(new TranslationContainer("waterdog.connected.fallback", targetServer.getServerName()));
         } else {
             this.disconnect(new TranslationContainer("waterdog.downstream.transfer.failed", targetServer.getServerName(), exceptionMessage));

--- a/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
+++ b/src/main/java/dev/waterdog/waterdogpe/player/ProxiedPlayer.java
@@ -405,7 +405,7 @@ public class ProxiedPlayer implements CommandSender {
         this.getLogger().error("[{}|{}] Unable to connect to downstream {}", this.getAddress(), this.getName(), targetServer.getServerName(), error);
         String exceptionMessage = Objects.requireNonNullElse(error.getLocalizedMessage(), error.getClass().getSimpleName());
 
-        if (this.clientConnection != null && this.clientConnection.isConnected()) {
+        if (this.clientConnection != null && this.clientConnection != connection && this.clientConnection.isConnected()) {
             this.sendMessage(new TranslationContainer("waterdog.downstream.transfer.failed", targetServer.getServerName(), exceptionMessage));
         } else if (this.sendToFallback(targetServer, ReconnectReason.EXCEPTION, exceptionMessage)) {
             this.sendMessage(new TranslationContainer("waterdog.connected.fallback", targetServer.getServerName()));


### PR DESCRIPTION
connectFailure previously fell through to sendToFallback and then disconnect() when a new downstream connection could not be established. sendToFallback returns false when the fallback server is null or equals the server the player is already on, so a failed transfer would kick a player who was still happily connected to their current server.

Now, if the player already has a live active downstream, just notify them that the transfer failed and leave them where they are. Fallback and disconnect are still used when there is no live connection (initial-join failure or a dead current server).