### PR TITLE
Add login-handshake timeout and fix ban enforcement behind HAProxy

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/network/connection/codec/server/ServerDatagramHandler.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/connection/codec/server/ServerDatagramHandler.java
@@ -21,6 +21,10 @@ import dev.waterdog.waterdogpe.security.SecurityManager;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.socket.DatagramPacket;
+import org.cloudburstmc.netty.channel.raknet.RakServerChannel;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 
 public class ServerDatagramHandler extends ChannelInboundHandlerAdapter {
     public static final String NAME = "server-datagram-handler";
@@ -33,7 +37,7 @@ public class ServerDatagramHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
-        if (msg instanceof DatagramPacket packet && this.manager.isAddressBlocked(packet.sender().getAddress())) {
+        if (msg instanceof DatagramPacket packet && this.manager.isAddressBlocked(this.resolveSource(ctx, packet.sender()))) {
             NetworkMetrics metrics = ProxyServer.getInstance().getNetworkMetrics();
             if (metrics != null) {
                 metrics.droppedBytes(packet.content().readableBytes());
@@ -42,5 +46,25 @@ public class ServerDatagramHandler extends ChannelInboundHandlerAdapter {
             return; // drop any incoming messages
         }
         ctx.fireChannelRead(msg);
+    }
+
+    /**
+     * Resolve a datagram's sender to the address bans are recorded against.
+     * <p>
+     * When running behind HAProxy (PROXY protocol enabled) datagrams arrive from the load balancer's
+     * address, while bans are keyed on the real client address (the RakNet child channel's remote
+     * address, which the library substitutes from the PROXY header). Without translating here, blocked
+     * clients would never be dropped. We resolve the sender to the real client via the parent
+     * {@link RakServerChannel}'s proxy-&gt;client mapping, falling back to the raw sender when PROXY
+     * protocol is disabled or the mapping has not been established yet.
+     */
+    private InetAddress resolveSource(ChannelHandlerContext ctx, InetSocketAddress sender) {
+        if (ctx.channel() instanceof RakServerChannel rakServerChannel) {
+            InetSocketAddress realClient = rakServerChannel.getClientAddress(sender);
+            if (realClient != null) {
+                return realClient.getAddress();
+            }
+        }
+        return sender.getAddress();
     }
 }

--- a/src/main/java/dev/waterdog/waterdogpe/network/protocol/handler/upstream/LoginUpstreamHandler.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/protocol/handler/upstream/LoginUpstreamHandler.java
@@ -32,9 +32,12 @@ import org.cloudburstmc.protocol.bedrock.codec.compat.BedrockCompat;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacketHandler;
 import org.cloudburstmc.protocol.bedrock.packet.*;
 import org.cloudburstmc.protocol.common.PacketSignal;
+import io.netty.channel.Channel;
+import io.netty.util.concurrent.ScheduledFuture;
 
 import java.net.InetSocketAddress;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The Pipeline Handler handling the login handshake part of the initial connect. Will be replaced after success.
@@ -47,6 +50,10 @@ public class LoginUpstreamHandler implements BedrockPacketHandler {
 
     // Whether login was allowed
     private boolean loginInitialized;
+    // Whether the login handshake completed successfully; guards the login-timeout task
+    private boolean loginCompleted;
+    // Kicks the connection if the login handshake is not completed in time
+    private ScheduledFuture<?> loginTimeoutFuture;
     // The compression used by this session
     // Defaults to ZLIB for older versions
     private CompressionType compression;
@@ -54,6 +61,36 @@ public class LoginUpstreamHandler implements BedrockPacketHandler {
     public LoginUpstreamHandler(ProxyServer proxy, BedrockServerSession session) {
         this.proxy = proxy;
         this.session = session;
+        this.scheduleLoginTimeout();
+    }
+
+    private void scheduleLoginTimeout() {
+        int timeout = this.proxy.getNetworkSettings().loginTimeout();
+        if (timeout <= 0) {
+            return;
+        }
+
+        Channel channel = this.session.getPeer().getChannel();
+        this.loginTimeoutFuture = channel.eventLoop().schedule(() -> {
+            if (this.loginCompleted || !this.session.isConnected()) {
+                return;
+            }
+            this.proxy.getLogger().warning("[{}] <-> Disconnecting: login handshake not completed within {}s", this.session.getSocketAddress(), timeout);
+            this.session.disconnect("Login timeout");
+            // Treat a stalled handshake like any other protocol violation so the source IP is throttled/blocked
+            this.proxy.getSecurityManager().onConnectionError(this.session.getSocketAddress(), null);
+        }, timeout, TimeUnit.SECONDS);
+
+        // Cancel the task if the connection closes for any other reason before it fires
+        channel.closeFuture().addListener(future -> this.cancelLoginTimeout());
+    }
+
+    private void cancelLoginTimeout() {
+        ScheduledFuture<?> future = this.loginTimeoutFuture;
+        if (future != null) {
+            future.cancel(false);
+            this.loginTimeoutFuture = null;
+        }
     }
 
     private void onLoginFailed(HandshakeEntry handshakeEntry, Throwable throwable, String disconnectReason) {
@@ -211,6 +248,9 @@ public class LoginUpstreamHandler implements BedrockPacketHandler {
             this.proxy.getSecurityManager().onConnectionError(this.session.getSocketAddress(), null);
             return;
         }
+
+        this.loginCompleted = true;
+        this.cancelLoginTimeout();
 
         PlayStatusPacket status = new PlayStatusPacket();
         status.setStatus(PlayStatusPacket.Status.LOGIN_SUCCESS);

--- a/src/main/java/dev/waterdog/waterdogpe/utils/config/proxy/NetworkSettings.java
+++ b/src/main/java/dev/waterdog/waterdogpe/utils/config/proxy/NetworkSettings.java
@@ -69,6 +69,11 @@ public class NetworkSettings extends YamlConfig {
     @Comment("How many seconds should a connection be blocked if an error is thrown. Set to 0 to disable.")
     private int errorTimeout = 15;
 
+    @Path("login_timeout")
+    @Accessors(fluent = true)
+    @Comment("How many seconds a connection has to complete the login handshake (network settings -> login -> client-to-server handshake) before it is disconnected. Set to 0 to disable.")
+    private int loginTimeout = 10;
+
     @Path("random_downstream_loopback_address")
     @Accessors(fluent = true)
     @Comment("Bind each downstream connection to a random 127.0.0.0/8 source address when the target server is on loopback. Certain server softwares like BDS rate limit connections per IP, this causes problems when transferring multiple players at the same time to a certain server. Requires an OS that allows binding the whole loopback range.")


### PR DESCRIPTION
## Summary

Two client-edge hardening changes to the RakNet ingress, implemented as small targeted enhancements to Waterdog's existing `SecurityManager`/login path.

### 1. Login-handshake timeout
Connections that establish RakNet but stall the Bedrock login handshake (`RequestNetworkSettings → Login → ClientToServerHandshake`) are now kicked.

- New `login_timeout` network setting (default **10s**, `0` disables), styled after `error_timeout`.
- `LoginUpstreamHandler` schedules a timeout on the session event loop at construction; on expiry it disconnects (`"Login timeout"`) and routes through `SecurityManager.onConnectionError`, so the source IP receives the existing behavior-ban treatment. Cancelled on successful login and on early channel close.

### 2. Ban enforcement behind HAProxy
`ServerDatagramHandler` dropped datagrams keyed on the raw sender. Behind HAProxy that is the **load balancer** address, while bans are recorded against the **real client** address (the RakNet child channel's remote address). Blocked clients were therefore never dropped at the edge, and blocking the HAProxy IP would drop everyone.

- Resolve the sender to the real client via `RakServerChannel.getClientAddress()` (the proxy→client map the RakNet lib populates from the PROXY header) before the block check.
- Falls back to the raw sender when PROXY protocol is disabled or the mapping is not yet established, so non-HAProxy setups are unchanged.

## Testing
- `./gradlew compileJava` passes.
- Not yet exercised end-to-end. Suggested checks:
  - **#1:** a client that connects then sends nothing should drop at ~`login_timeout`; verify legitimate slow auth/resource-pack flows don't trip it.
  - **#2:** with `enable_proxy_protocol: true`, ban an IP and confirm its datagrams drop at the edge (`droppedBytes` metric increments) rather than reaching session creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)