### PR TITLE
Avoid re-encoding unmodified chat packets

### DIFF
--- a/src/main/java/dev/waterdog/waterdogpe/network/protocol/handler/upstream/ConnectedUpstreamHandler.java
+++ b/src/main/java/dev/waterdog/waterdogpe/network/protocol/handler/upstream/ConnectedUpstreamHandler.java
@@ -85,13 +85,19 @@ public class ConnectedUpstreamHandler extends AbstractUpstreamHandler implements
 
     @Override
     public final PacketSignal handle(TextPacket packet) {
-        PlayerChatEvent event = new PlayerChatEvent(this.player, packet.getMessage());
+        String oldMessage = packet.getMessage();
+        PlayerChatEvent event = new PlayerChatEvent(this.player, oldMessage);
         ProxyServer.getInstance().getEventManager().callEvent(event);
-        packet.setMessage(event.getMessage());
+
         if (event.isCancelled()) {
             return Signals.CANCEL;
         }
-        return PacketSignal.HANDLED;
+
+        if (!oldMessage.equals(event.getMessage())) {
+            packet.setMessage(event.getMessage());
+            return PacketSignal.HANDLED;
+        }
+        return PacketSignal.UNHANDLED;
     }
 
     @Override


### PR DESCRIPTION
## Problem

`ConnectedUpstreamHandler.handle(TextPacket)` always returned `PacketSignal.HANDLED`. In `ProxyBatchBridge.onBedrockBatch`, a `HANDLED` signal releases the packet's cached wire buffer and calls `batch.modify()`, which forces the batch to be **re-encoded and re-compressed** on the way out — even when nothing about the packet actually changed.

Since `PlayerChatEvent` is dispatched for every chat packet and the handler unconditionally signalled `HANDLED`, every chat message was re-serialized and its batch re-compressed on the Netty event loop regardless of whether any listener modified the message. Under a burst/flood of chat packets this is a per-packet encode + zlib compression that scales directly with chat volume.

## Change

Return `HANDLED` only when a listener actually rewrote the message; otherwise return `UNHANDLED` so the original wire bytes pass through untouched (no re-encode, no re-compress). Cancellation behaviour is unchanged.

This mirrors the convention already used elsewhere in the codebase — e.g. `AbstractDownstreamHandler.handle(AvailableCommandsPacket)` returns `UNHANDLED` when it adds no commands and only `HANDLED` after it mutates the packet.

Plugin packet handlers that mutate the packet still work: their `HANDLED` is merged in `ProxyBatchBridge.handlePacket` via `Signals.mergeSignals`, forcing a re-encode independently of this check. The message is the only field `PlayerChatEvent` exposes, so it is the only field this handler can change — hence the single `message` comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)